### PR TITLE
Support for short scalar types in derived MRI pixel data

### DIFF
--- a/libs/src/svkDcmHeader.cc
+++ b/libs/src/svkDcmHeader.cc
@@ -2418,6 +2418,10 @@ int svkDcmHeader::InitDerivedMRIHeader(svkDcmHeader* mri, vtkIdType dataType, st
         dcmDataType = svkDcmHeader::SIGNED_FLOAT_8;
     } else if ( dataType == VTK_FLOAT ) {
         dcmDataType = svkDcmHeader::SIGNED_FLOAT_4;
+    } else if ( dataType == VTK_SHORT ) {
+        dcmDataType = svkDcmHeader::SIGNED_INT_2;
+    } else if ( dataType == VTK_UNSIGNED_SHORT ) {
+        dcmDataType = svkDcmHeader::UNSIGNED_INT_2;
     } else {
         cout << this->GetClassName() << ": Unsupported ScalarType " << dataType << endl;
         exit(1);


### PR DESCRIPTION
This is a very small change, adding in `VTK_SHORT` and `VTK_UNSIGNED_SHORT` as supported datatypes in `svkDcmHeader::InitDerivedMRIHeader`. The use case is for creating a new `svkMriImageData` object, and basing it off of an existing image, using `GetImage()` to create an empty pixel data array. If you want to keep the data array size/shape, but change the datatype, the current behavior only allows you to specify `VTK_FLOAT` as the new image's datatype. This change allows for short values. Usage example below:

    svkMriImageData* integerMap = svkMriImageData::New();
    svkMriImageData::SafeDownCast(reader->GetOutput())->GetCellDataRepresentation()->GetImage(integerMap,
                                                                                              0,
                                                                                              "New Integer Map",
                                                                                              NULL,
                                                                                              0,
                                                                                              VTK_UNSIGNED_SHORT);

I currently need this to calculate an ADC map, from a 4D DWI dataset, and write out results as a dicom image with integer values.