### PR TITLE
Fix for reslice update issues.

### DIFF
--- a/libs/src/svkObliqueReslice.h
+++ b/libs/src/svkObliqueReslice.h
@@ -125,7 +125,8 @@ class svkObliqueReslice : public svkImageAlgorithmWithPortMapper
         void                SetRotationMatrix( );
         void                Print3x3(double matrix[3][3], string name);
         bool                IsDcosInitialized(); 
-        bool                Magnify(); 
+        bool                Magnify();
+        void                ComputeTopLeftCorner(double newTlc[3]);
 
 
 


### PR DESCRIPTION
This bugfix is for an issue that causes the reference image slice to be rendered in the wrong location after an image has been resliced and visualized in the SIVIC GUI. This is due to incorrect information in the output information of the svkObliqueReslice algorithm. The data is resliced appropriately but the vtkInformation objects do not reflect the correct origin. The fix was to compute the correct origin in svkObliqueReslice::RequestInformation. 