### PR TITLE
Fixed a bug in svk_point_selector that caused the cursor to not appear.

### DIFF
--- a/applications/cmd_line/src/svk_point_selector.cc
+++ b/applications/cmd_line/src/svk_point_selector.cc
@@ -300,7 +300,7 @@ int main ( int argc, char** argv )
 	vtkPolyDataMapper* mapper = vtkPolyDataMapper::New();
 	sphereActor->SetMapper( mapper);
 	sphereActor->GetProperty()->SetDiffuseColor(1,1,1 );
-	mapper->SetInputData( globalVars.sphere->GetOutput() );
+	mapper->SetInputConnection( globalVars.sphere->GetOutputPort() );
 
     // Lets create setup our window and renderers
 	globalVars.window = vtkRenderWindow::New();
@@ -498,12 +498,12 @@ void SetupImageViewer( double position[4], svkDcmHeader::Orientation orientation
 			line->SetPoint1(lineLength*orthSliceNormal[0] + disp*sliceNormal[0], lineLength*orthSliceNormal[1] + disp*sliceNormal[1], lineLength*orthSliceNormal[2] + disp*sliceNormal[2] );
 			line->SetPoint2(-lineLength*orthSliceNormal[0] + disp*sliceNormal[0], -lineLength*orthSliceNormal[1] + disp*sliceNormal[1], -lineLength*orthSliceNormal[2] + disp*sliceNormal[2] );
 			vtkGlyph3D* glyph = vtkGlyph3D::New();
-			glyph->SetSourceData( line->GetOutput() );
+			glyph->SetSourceConnection( line->GetOutputPort() );
 			glyph->SetInputData(pd);
 			vtkActor* cursorActor = vtkActor::New();
 			vtkPolyDataMapper* mapper = vtkPolyDataMapper::New();
 			cursorActor->GetProperty()->SetLineWidth(1);
-			mapper->SetInputData( glyph->GetOutput() );
+			mapper->SetInputConnection( glyph->GetOutputPort() );
 			cursorActor->SetMapper( mapper );
 			cursorActor->GetProperty()->SetColor(globalVars.inactiveCursorColor);
 			imageViewer->GetRenderer()->AddActor( cursorActor );
@@ -770,7 +770,7 @@ void UpdateCursorLocation(vtkObject* subject, unsigned long eid, void* thisObjec
 
 
 /*!
- * Displays the usage message.
+ * Displays the usage message
  */
 void DisplayUsage( void )
 {

--- a/libs/src/svkImageActor.cc
+++ b/libs/src/svkImageActor.cc
@@ -111,11 +111,14 @@ void svkImageActor::ComputeMatrix()
 
             vtkTransform* rotationTransform = vtkTransform::New();
             rotationTransform->Identity();
+            vtkMatrix4x4* rotationMatrix = vtkMatrix4x4::New();
             for( int i = 0; i < 3; i++) {
                 for( int j = 0; j < 3; j++) {
-                    rotationTransform->GetMatrix()->SetElement(i,j,dcos[j][i]);
+                    rotationMatrix->SetElement(i,j,dcos[j][i]);
                 }
             }
+            rotationTransform->SetMatrix(rotationMatrix);
+            rotationMatrix->Delete();
 
             vtkTransform* retranslate = vtkTransform::New();
             retranslate->Identity();


### PR DESCRIPTION
This PR is to fix an issue caused by the upgrade to vtk 6 which prevented the cursors from appearing in svk_point_selector. Additionally a warning message was fixed with regards to vtkTransform.