### PR TITLE
validated svk_mrs_combine vs combine_spec_v6 weighted combination functions

### DIFF
--- a/applications/cmd_line/src/svk_combine_spec.cc
+++ b/applications/cmd_line/src/svk_combine_spec.cc
@@ -180,7 +180,9 @@ int main (int argc, char** argv)
         char numstr[10];
         sprintf(numstr, "%d", pnt);
         currentInputFile.assign(inputRoot.c_str());
-        currentInputFile.append("_real");
+        if ( handleComplex ){
+        	currentInputFile.append("_real");
+        }
         currentInputFile.append(numstr);
         currentInputFile.append(".idf");
        // currentOutputFile.append(".dcm");


### PR DESCRIPTION
-a 5 and -a4 match with combine_spec.  Note that -a4 defaults to a different scaling now, but using the old scaling the results are the same.  However, -a5 is what we are using in production.