### PR TITLE
Feature/sym ep

### DIFF
--- a/libs/src/svkEPSIPhaseCorrect.cc
+++ b/libs/src/svkEPSIPhaseCorrect.cc
@@ -70,7 +70,8 @@ svkEPSIPhaseCorrect::svkEPSIPhaseCorrect()
     this->epsiOrigin = -1;
     this->epsiSpatialPhaseCorrection = NULL;
     this->symEPSIPhaseArray = NULL; 
-
+    this->epsiType =  svkEPSIReorder::FLYBACK; 
+    this->phaseSlope = 1;   //positive slope shifts points to left
 }
 
 
@@ -81,6 +82,14 @@ svkEPSIPhaseCorrect::~svkEPSIPhaseCorrect()
 {
 }
 
+
+/*!
+ *  Set the epsi type 
+ */
+void svkEPSIPhaseCorrect::SetEPSIType( svkEPSIReorder::EPSIType type )
+{
+    this->epsiType = type;
+}
 
 /*!
  *  Set the number of k-space samples along the EPSI encoding 
@@ -260,55 +269,61 @@ int svkEPSIPhaseCorrect::RequestData( vtkInformation* request, vtkInformationVec
  */
 void svkEPSIPhaseCorrect::PhaseAlternatingSymmetricEPSILobes( int cellID )
 {
-    //  Get pointer to input data set. 
-    svkMrsImageData* mrsData = svkMrsImageData::SafeDownCast(this->GetImageDataInput(0)); 
 
-    //  Get pointer to data's meta-data header (DICOM object). 
-    svkDcmHeader* hdr = mrsData->GetDcmHeader();  
-
-    int numSpecPts = hdr->GetIntValue( "DataPointColumns" );
-
-    svkDcmHeader::DimensionVector dimensionVector = hdr->GetDimensionIndexVector();
-    svkDcmHeader::DimensionVector indexVector = dimensionVector; 
-    svkDcmHeader::GetDimensionVectorIndexFromCellID( &dimensionVector, &indexVector, cellID ); 
-    int epsiLobeIndex = svkDcmHeader::GetDimensionVectorValue( &indexVector, svkDcmHeader::EPSI_ACQ_INDEX);  
-    cout << "EPSI LOBE INDEX: " << epsiLobeIndex << endl;
-    if ( epsiLobeIndex == 1 ) {
-
-        if ( this->symEPSIPhaseArray == NULL ) {
-            double freqIncrement;
-            float  fOrigin = (numSpecPts)/2; 
-            double mult;
-            double Pi      = vtkMath::Pi();
-            this->symEPSIPhaseArray = new vtkImageComplex[ numSpecPts ];
-            for( int f = 0; f <  numSpecPts; f++ ) {
-                freqIncrement = ( f - fOrigin ) / ( numSpecPts );
-                mult = Pi * freqIncrement;
-                this->symEPSIPhaseArray[f].Real = cos( mult );
-                this->symEPSIPhaseArray[f].Imag = sin( mult );
-            }
-        }
-
-        cout << "Apply sym epsi phase correction" << endl;
-        vtkFloatArray* spectrum = vtkFloatArray::SafeDownCast( mrsData->GetSpectrum( cellID ) );
-        float cmplxPtIn[2];
-        float cmplxPtPhased[2];
-        float epsiPhase[2];
-
-        for ( int freq = 0; freq < numSpecPts; freq++ ) {
-            spectrum->GetTupleValue(freq, cmplxPtIn);
-            cout << " phase " << freq << " " <<  this->symEPSIPhaseArray[freq].Real << endl;
-            epsiPhase[0] = this->symEPSIPhaseArray[freq].Real; 
-            epsiPhase[1] = this->symEPSIPhaseArray[freq].Imag; 
-
-            cmplxPtPhased[0] = cmplxPtIn[0] * epsiPhase[0] + cmplxPtIn[1] * epsiPhase[1]; 
-            cmplxPtPhased[1] = cmplxPtIn[1] * epsiPhase[0] - cmplxPtIn[0] * epsiPhase[1]; 
-
-            spectrum->SetTuple(freq, cmplxPtPhased); 
-        }
+    if ( this->epsiType == svkEPSIReorder::SYMMETRIC ) {
+        //  Get pointer to input data set. 
+        svkMrsImageData* mrsData = svkMrsImageData::SafeDownCast(this->GetImageDataInput(0)); 
     
+        //  Get pointer to data's meta-data header (DICOM object). 
+        svkDcmHeader* hdr = mrsData->GetDcmHeader();  
+    
+        int numSpecPts = hdr->GetIntValue( "DataPointColumns" );
+    
+        svkDcmHeader::DimensionVector dimensionVector = hdr->GetDimensionIndexVector();
+        svkDcmHeader::DimensionVector indexVector = dimensionVector; 
+        svkDcmHeader::GetDimensionVectorIndexFromCellID( &dimensionVector, &indexVector, cellID ); 
+        int epsiLobeIndex = svkDcmHeader::GetDimensionVectorValue( &indexVector, svkDcmHeader::EPSI_ACQ_INDEX);  
+        //cout << "EPSI LOBE INDEX: " << epsiLobeIndex << endl;
+        if ( epsiLobeIndex == 1 ) {
+   
+            //  initialize the phase correction array if necessary 
+            if ( this->symEPSIPhaseArray == NULL ) {
+                cout << "Apply sym epsi phase correction" << endl;
+                double freqIncrement;
+                float  fOrigin = (numSpecPts)/2; 
+                double mult;
+                double Pi      = vtkMath::Pi();
+                double factor = this->phaseSlope * Pi; 
+                this->symEPSIPhaseArray = new vtkImageComplex[ numSpecPts ];
+                for( int f = 0; f <  numSpecPts; f++ ) {
+                    freqIncrement = ( f - fOrigin ) / ( numSpecPts );
+                    mult = factor * freqIncrement;
+                    this->symEPSIPhaseArray[f].Real = cos( mult );
+                    this->symEPSIPhaseArray[f].Imag = sin( mult );
+                }
+            }
+    
+            vtkFloatArray* spectrum = vtkFloatArray::SafeDownCast( mrsData->GetSpectrum( cellID ) );
+            float cmplxPtIn[2];
+            float cmplxPtPhased[2];
+            float epsiPhase[2];
+    
+            for ( int freq = 0; freq < numSpecPts; freq++ ) {
+                spectrum->GetTupleValue(freq, cmplxPtIn);
+                //cout << " phase " << freq << " " <<  this->symEPSIPhaseArray[freq].Real << endl;
+                epsiPhase[0] = this->symEPSIPhaseArray[freq].Real; 
+                epsiPhase[1] = this->symEPSIPhaseArray[freq].Imag; 
+    
+                cmplxPtPhased[0] = cmplxPtIn[0] * epsiPhase[0] + cmplxPtIn[1] * epsiPhase[1]; 
+                cmplxPtPhased[1] = cmplxPtIn[1] * epsiPhase[0] - cmplxPtIn[0] * epsiPhase[1]; 
+    
+                spectrum->SetTuple(freq, cmplxPtPhased); 
+            }
+        
+        }
     }
 }
+
 
 
 /*!
@@ -355,16 +370,25 @@ void svkEPSIPhaseCorrect::CreateEPSIPhaseCorrectionFactors( vtkImageComplex** ep
     cout <<  "num k pts read: " << numEPSIkRead << endl;
     cout << " EPSI ORIGIN: " << kOrigin << endl;
     cout << " FREQ ORIGIN: " << fOrigin << endl;
+
     double dtBs = 1./static_cast<float>(this->numEPSIkRead);
+    dtBs *= this->phaseSlope * 2 * Pi; 
+    //  if sym EPSI divide mult by 2 since the cycle (num points in spectral bandwith is 
+    //  twice as big)
+    if ( this->epsiType == svkEPSIReorder::SYMMETRIC ) {
+        dtBs /= 2; 
+    }
+
     //  certainly need a factor of 2 for interleaved, but a factor of 4?  Not sure
     cout << "Need to resolve this factor in different implementations" << endl;
     cout << "DTBS: " << dtBs << endl;
+    //  apply a positively sloping linear phase to shift data points back to the left.     
+    //  shift should be 
     for( int k = 0; k < numKPts ; k++ ) {
         for( int f = 0; f <  numSpecPts; f++ ) {
             kIncrement = ( k - kOrigin );
             freqIncrement = ( f - fOrigin ) / ( numSpecPts );
-            mult = 2 * Pi * dtBs * kIncrement * freqIncrement;
-            //mult = -1 * 2 * Pi * dtBs * kIncrement * freqIncrement;
+            mult = dtBs * kIncrement * freqIncrement;
             epsiPhaseArray[k][f].Real = cos( mult );
             epsiPhaseArray[k][f].Imag = sin( mult );
 

--- a/libs/src/svkEPSIPhaseCorrect.h
+++ b/libs/src/svkEPSIPhaseCorrect.h
@@ -111,13 +111,15 @@ class svkEPSIPhaseCorrect : public svkImageInPlaceFilter
 
         void            CreateEPSIPhaseCorrectionFactors( vtkImageComplex** phaseArray, int numSpecPts ); 
         int             SpectralFFT( svkMrsImageFFT::FFTMode direction ); 
+        void            PhaseAlternatingSymmetricEPSILobes( int cellID ); 
 
 
-        int             numEPSIkRead;
-        int             epsiAxis;
-        float           epsiOrigin;
-        double*         epsiSpatialPhaseCorrection;
-        svkImageData*   tmpData; 
+        int                 numEPSIkRead;
+        int                 epsiAxis;
+        float               epsiOrigin;
+        double*             epsiSpatialPhaseCorrection;
+        vtkImageComplex*    symEPSIPhaseArray; 
+        svkImageData*       tmpData; 
 
 
 };

--- a/libs/src/svkEPSIPhaseCorrect.h
+++ b/libs/src/svkEPSIPhaseCorrect.h
@@ -48,6 +48,7 @@
 
 #include <svkMrsImageFFT.h>
 #include <svkImageInPlaceFilter.h>
+#include <svkEPSIReorder.h>
 
 
 namespace svk {
@@ -90,6 +91,7 @@ class svkEPSIPhaseCorrect : public svkImageInPlaceFilter
         void            SetEPSIAxis( int epsiAxis );
         void            SetEPSIOrigin( float epsiOrigin );
         float           GetEPSIOrigin();
+        void            SetEPSIType( svkEPSIReorder::EPSIType type ); 
 
 
     protected:
@@ -114,13 +116,14 @@ class svkEPSIPhaseCorrect : public svkImageInPlaceFilter
         void            PhaseAlternatingSymmetricEPSILobes( int cellID ); 
 
 
-        int                 numEPSIkRead;
-        int                 epsiAxis;
-        float               epsiOrigin;
-        double*             epsiSpatialPhaseCorrection;
-        vtkImageComplex*    symEPSIPhaseArray; 
-        svkImageData*       tmpData; 
-
+        int                      numEPSIkRead;
+        int                      epsiAxis;
+        float                    epsiOrigin;
+        double*                  epsiSpatialPhaseCorrection;
+        vtkImageComplex*         symEPSIPhaseArray; 
+        svkImageData*            tmpData; 
+        svkEPSIReorder::EPSIType epsiType; 
+        int                      phaseSlope; 
 
 };
 

--- a/libs/src/svkGEPFileMapperUCSFfidcsiDev0.cc
+++ b/libs/src/svkGEPFileMapperUCSFfidcsiDev0.cc
@@ -696,6 +696,7 @@ void svkGEPFileMapperUCSFfidcsiDev0::EPSIPhaseCorrection( svkImageData* data, in
     numRead -= 2; 
     epsiPhase->SetNumEPSIkRead( numRead );
     epsiPhase->SetEPSIAxis( epsiAxis );
+    epsiPhase->SetEPSIType( svkEPSIReorder::SYMMETRIC ); 
     epsiPhase->SetInputData( tmpData ); 
     //tmpData->GetDcmHeader()->PrintDcmHeader(); 
     epsiPhase->Update(); 


### PR DESCRIPTION
fixed first order phasing of even (negative) lobes to support complex lobe combination and complex analysis of SYM epsi data.   convert raw files to ddf and then load as single the two lobes in complex mode.  the phase looks correct now between the two lobes. 

all tests passes with updates to the sym epsi data test cases. 