### PR TITLE
Feature/dad api extension

### DIFF
--- a/applications/cmd_line/src/svk_dcmdump.cc
+++ b/applications/cmd_line/src/svk_dcmdump.cc
@@ -110,6 +110,7 @@ void DisplayUsage( )
     cout << "    svk_dcmdump fileName" << endl << endl;
     cout << "DESCRIPTION" << endl;
     cout << "    svk_dcmdump is used to give a quick way to view svk's interpreted DICOM header of a given image file." << endl << endl;
+    cout << "    -v will also print vtk obect information." << endl << endl;
     cout << "VERSION" << endl;
     cout << "     " << SVK_RELEASE_VERSION << endl; 
     cout << endl << "############  USAGE  ############ " << endl << endl;

--- a/applications/cmd_line/src/svk_gepfile_reader.cc
+++ b/applications/cmd_line/src/svk_gepfile_reader.cc
@@ -146,7 +146,7 @@ int main (int argc, char** argv)
     bool    dcCorrection      = true; 
     bool    printHeader       = false; 
     bool    printShortHeader  = false; 
-    svkEPSIReorder::EPSIType epsiType = svkEPSIReorder::UNDEFINED_EPSI_TYPE;
+    EPSIType epsiType         = UNDEFINED_EPSI_TYPE;
     int     epsiAxis          = UNDEFINED;
     int     epsiNumLobes      = UNDEFINED;
     int     epsiSkip          = UNDEFINED;
@@ -241,7 +241,7 @@ int main (int argc, char** argv)
                 chopString.assign(optarg);
                 break;
             case FLAG_EPSI_TYPE:
-                epsiType = static_cast<svkEPSIReorder::EPSIType>(atoi(optarg));
+                epsiType = static_cast<EPSIType>(atoi(optarg));
                 break;
             case FLAG_EPSI_AXIS:
                 //  axis ordering starts at 0
@@ -300,7 +300,7 @@ int main (int argc, char** argv)
             exit(1); 
         }
         //  validate EPSI input if necessary:
-        if ( epsiType != svkEPSIReorder::UNDEFINED_EPSI_TYPE ) { 
+        if ( epsiType != UNDEFINED_EPSI_TYPE ) {
             if (
                 epsiNumLobes == UNDEFINED ||
                 epsiSkip == UNDEFINED ||
@@ -409,7 +409,7 @@ int main (int argc, char** argv)
 
 
     //  Set EPSI params if necessary in reader: 
-    if ( epsiType != svkEPSIReorder::UNDEFINED_EPSI_TYPE ) { 
+    if ( epsiType != UNDEFINED_EPSI_TYPE ) {
         reader->SetEPSIParams( 
             epsiType, 
             static_cast<svkEPSIReorder::EPSIAxis>(epsiAxis), 
@@ -419,7 +419,7 @@ int main (int argc, char** argv)
             epsiFlipLobe
         );
     }
-    if ( epsiType == svkEPSIReorder::UNDEFINED_EPSI_TYPE && epsiFlipLobe != 0 ) { 
+    if ( epsiType == UNDEFINED_EPSI_TYPE && epsiFlipLobe != 0 ) {
         reader->SetEPSIParams( 
             epsiFlipLobe
         );

--- a/applications/cmd_line/src/svk_point_selector.cc
+++ b/applications/cmd_line/src/svk_point_selector.cc
@@ -795,7 +795,7 @@ void CaptureWindow()
         extension = "jpeg";
     }
 
-    if(globalVars.primaryWindow != NULL ) {
+    if(globalVars.window != NULL ) {
         svkVizUtils::SaveWindow( globalVars.window, globalVars.captureFile);
     }
 }

--- a/applications/cmd_line/src/svk_reorder_epsi.cc
+++ b/applications/cmd_line/src/svk_reorder_epsi.cc
@@ -149,7 +149,7 @@ int main (int argc, char** argv)
     bool  reorder            = true; // default
     bool  phaseCorrect       = false;
     bool  combineLobes       = false;
-    svkEPSIReorder::EPSIType type  = svkEPSIReorder::UNDEFINED_EPSI_TYPE;
+    EPSIType type  = UNDEFINED_EPSI_TYPE;
 
     string cmdLine = svkProvenance::GetCommandLineString( argc, argv ); 
 
@@ -226,7 +226,7 @@ int main (int argc, char** argv)
                 epsiAxis = atoi(optarg) - 1;
                 break;
             case FLAG_TYPE:
-                type = static_cast<svkEPSIReorder::EPSIType>(atoi(optarg));
+                type = static_cast<EPSIType>(atoi(optarg));
                 break;
             case FLAG_COMBINE_LOBES:
                 combineLobes = true;
@@ -270,7 +270,7 @@ int main (int argc, char** argv)
             skip == UNDEFINED ||
             first < 0 ||
             epsiAxis < 0 || epsiAxis > 2 ||
-            type == svkEPSIReorder::UNDEFINED_EPSI_TYPE ||
+            type == UNDEFINED_EPSI_TYPE ||
             outputFileName.length() == 0 ||
             inputFileName.length() == 0  ||
             ( dataTypeOut != svkImageWriterFactory::DICOM_MRS && dataTypeOut != svkImageWriterFactory::DDF ) ||

--- a/libs/src/svkDataAcquisitionDescriptionXML.cc
+++ b/libs/src/svkDataAcquisitionDescriptionXML.cc
@@ -712,14 +712,14 @@ vtkXMLDataElement* svkDataAcquisitionDescriptionXML::FindOrCreateNestedElementWi
  *  \param xmlPath the xpath to the element
  *  \return the contents of the element at the given path
  */
-const char * svkDataAcquisitionDescriptionXML::GetDataWithPath( const char* xmlPath )
+string svkDataAcquisitionDescriptionXML::GetDataWithPath( const char* xmlPath )
 {
     string data = "";
     bool foundData = svkXMLUtils::GetNestedElementCharacterDataWithPath( this->dataAcquisitionDescriptionXML, xmlPath, &data );
     if( !foundData ) {
         cout << "ERROR: Could get character data at path: " << xmlPath << endl;
     }
-    return data.c_str();
+    return data;
 }
 
 
@@ -809,7 +809,7 @@ void svkDataAcquisitionDescriptionXML::SetFloatWithPath( const char* parentPath,
  * @param parentPath
  * @return
  */
-const char * svkDataAcquisitionDescriptionXML::GetDataByIndexWithParentPath( int index, const char* parentPath )
+string svkDataAcquisitionDescriptionXML::GetDataByIndexWithParentPath( int index, const char* parentPath )
 {
     vtkXMLDataElement* element = this->GetNestedElementByIndexWithParentPath(index, parentPath);
     if( element != NULL ) {
@@ -967,10 +967,10 @@ EPSIType svkDataAcquisitionDescriptionXML::GetEPSIType()
  *
  * @return
  */
-const char* svkDataAcquisitionDescriptionXML::GetEPSITypeString()
+string svkDataAcquisitionDescriptionXML::GetEPSITypeString()
 {
     string epsiTypeFromDad = this->GetDataWithPath("/encoding/trajectoryDescription/epsiEncoding/epsiType");
-    return epsiTypeFromDad.c_str();
+    return epsiTypeFromDad;
 }
 
 
@@ -1303,7 +1303,7 @@ int svkDataAcquisitionDescriptionXML::GetEncodedMatrixSizeDimensionValue(int ind
  * @param index
  * @return
  */
-const char* svkDataAcquisitionDescriptionXML::GetEncodedMatrixSizeDimensionName(int index)
+string svkDataAcquisitionDescriptionXML::GetEncodedMatrixSizeDimensionName(int index)
 {
     string parentPath = "encoding/encodedSpace/matrixSize";
     return this->GetDataByIndexWithParentPath(index, parentPath.c_str());

--- a/libs/src/svkDataAcquisitionDescriptionXML.cc
+++ b/libs/src/svkDataAcquisitionDescriptionXML.cc
@@ -266,7 +266,7 @@ string svkDataAcquisitionDescriptionXML::GetTrajectoryDimensionDescription(int i
  *
  * @param type
  */
-void svkDataAcquisitionDescriptionXML::SetEPSIType( enum EPSIType type ) {
+void svkDataAcquisitionDescriptionXML::SetEPSIType( EPSIType type ) {
 
     string parentPath = "encoding/trajectoryDescription/epsiEncoding";
     // Thes meethod coll ensures the EPSI encoding element is created already.
@@ -1700,7 +1700,7 @@ void svkDataAcquisitionDescriptionXML_SetEPSITypeToSymmetric(void* xml) {
  * @param type
  * @param xml
  */
-void svkDataAcquisitionDescriptionXML_SetEPSIType( enum EPSIType type, void* xml) {
+void svkDataAcquisitionDescriptionXML_SetEPSIType( EPSIType type, void* xml) {
     if( xml != NULL ) {
         ((svkDataAcquisitionDescriptionXML*)xml)->SetEPSIType( type );
     } else {
@@ -1714,7 +1714,7 @@ void svkDataAcquisitionDescriptionXML_SetEPSIType( enum EPSIType type, void* xml
  * @param xml
  * @return
  */
-enum EPSIType svkDataAcquisitionDescriptionXML_GetEPSIType(void* xml)
+EPSIType svkDataAcquisitionDescriptionXML_GetEPSIType(void* xml)
 {
     if( xml != NULL ) {
         return ((svkDataAcquisitionDescriptionXML*)xml)->GetEPSIType( );

--- a/libs/src/svkDataAcquisitionDescriptionXML.cc
+++ b/libs/src/svkDataAcquisitionDescriptionXML.cc
@@ -163,6 +163,134 @@ string svkDataAcquisitionDescriptionXML::GetTrajectoryComment( )
 
 
 /*!
+ *
+ * @return
+ */
+int svkDataAcquisitionDescriptionXML::GetTrajectoryNumberOfDimensions()
+{
+    string parentPath = "encoding/trajectoryDescription/dimensions";
+    vtkXMLDataElement* parentElement = svkXMLUtils::FindNestedElementWithPath(this->GetRootXMLDataElement(), parentPath);
+    if( parentElement != NULL ) {
+        return parentElement->GetNumberOfNestedElements();
+    } else {
+        return -1;
+    }
+}
+
+
+/*!
+ *
+ * @param id
+ * @param logical
+ * @param description
+ */
+void svkDataAcquisitionDescriptionXML::AddTrajectoryDimension(string id, string logical, string description)
+{
+    string parentPath = "encoding/trajectoryDescription/dimensions";
+    string elementName = parentPath;
+    elementName.append("/dim");
+    vtkXMLDataElement* dimElement = this->AddElementWithParentPath(parentPath.c_str(), "dim");
+    dimElement->SetAttribute("id", id.c_str());
+    if( !logical.empty()) {
+        vtkXMLDataElement* logicalElement = vtkXMLDataElement::New();
+        logicalElement->SetCharacterData(logical.c_str(), logical.size());
+        logicalElement->SetName("logical");
+        dimElement->AddNestedElement(logicalElement);
+        logicalElement->Delete();
+    }
+    if( !description.empty()) {
+        vtkXMLDataElement* descriptionElement = vtkXMLDataElement::New();
+        descriptionElement->SetCharacterData(description.c_str(), description.size());
+        descriptionElement->SetName("description");
+        dimElement->AddNestedElement(descriptionElement);
+        descriptionElement->Delete();
+    }
+}
+
+
+/*!
+ *
+ * @param index
+ * @return
+ */
+string svkDataAcquisitionDescriptionXML::GetTrajectoryDimensionId(int index)
+{
+    string parentPath = "encoding/trajectoryDescription/dimensions/";
+    vtkXMLDataElement* element = this->GetNestedElementByIndexWithParentPath(index, parentPath.c_str());
+    if( element != NULL) {
+        return element->GetAttribute("id");
+    }
+    return "";
+}
+
+
+/*!
+ *
+ * @param index
+ * @return
+ */
+string svkDataAcquisitionDescriptionXML::GetTrajectoryDimensionLogical(int index)
+{
+    string parentPath = "encoding/trajectoryDescription/dimensions/";
+    vtkXMLDataElement* element = this->GetNestedElementByIndexWithParentPath(index, parentPath.c_str());
+    if( element != NULL ) {
+        vtkXMLDataElement* logical = svkXMLUtils::FindNestedElementWithPath( element, "logical");
+        if( logical != NULL ) {
+            return logical->GetCharacterData();
+        }
+    }
+    return "";
+}
+
+
+/*!
+ *
+ * @param index
+ * @return
+ */
+string svkDataAcquisitionDescriptionXML::GetTrajectoryDimensionDescription(int index)
+{
+    string parentPath = "encoding/trajectoryDescription/dimensions/";
+    vtkXMLDataElement* element = this->GetNestedElementByIndexWithParentPath(index, parentPath.c_str());
+    if( element != NULL ) {
+        vtkXMLDataElement* description = svkXMLUtils::FindNestedElementWithPath( element, "description");
+        if( description != NULL ) {
+            return description->GetCharacterData();
+        }
+    }
+    return "";
+}
+
+
+/*!
+ *
+ * @param type
+ */
+void svkDataAcquisitionDescriptionXML::SetEPSIType( enum EPSIType type ) {
+
+    string parentPath = "encoding/trajectoryDescription/epsiEncoding";
+    // Thes meethod coll ensures the EPSI encoding element is created already.
+    this->GetEPSIEncodingElement();
+
+    string elementName = parentPath;
+    elementName.append("/epsiType");
+    vtkXMLDataElement* epsiTypeElement = this->FindNestedElementWithPath(elementName);
+    if( epsiTypeElement == NULL ) {
+        epsiTypeElement = this->AddElementWithParentPath(parentPath.c_str(), "epsiType");
+    }
+    if( type == FLYBACK ) {
+        epsiTypeElement->SetCharacterData("FLYBACK", 7);
+    } else if (type == SYMMETRIC) {
+        epsiTypeElement->SetCharacterData("SYMMETRIC", 9);
+    } else if (type == INTERLEAVED) {
+        epsiTypeElement->SetCharacterData("INTERLEAVED", 11);
+    } else {
+        epsiTypeElement->SetCharacterData("UNDEFINED_EPSI_TYPE", 19);
+    }
+}
+
+
+/*!
  * Creates a new encoding/trajectoryDescription/userParameterLong element and
  * creates its child elements 'name' and 'value' with the given values.
  * \param name the of the new user parameter element
@@ -215,6 +343,22 @@ void svkDataAcquisitionDescriptionXML::SetTrajectoryParameter( string name, doub
 
 
 /*!
+ *
+ * @return
+ */
+vtkXMLDataElement* svkDataAcquisitionDescriptionXML::GetEPSIEncodingElement()
+{
+    string parentPath = "encoding/trajectoryDescription";
+    string elementPath = "encoding/trajectoryDescription/epsiEncoding";
+    vtkXMLDataElement* epsiEncodingElement = this->FindNestedElementWithPath(elementPath);
+    if( epsiEncodingElement == NULL ) {
+        epsiEncodingElement = this->AddElementWithParentPath(parentPath.c_str(), "epsiEncoding");
+    }
+    return epsiEncodingElement;
+}
+
+
+/*!
  * Initialize the skeleton of the xml file. This will create the following elements:
  * svk_data_acquisition_description
  * svk_data_acquisition_description/version
@@ -222,6 +366,7 @@ void svkDataAcquisitionDescriptionXML::SetTrajectoryParameter( string name, doub
  * svk_data_acquisition_description/encoding/trajectory
  * svk_data_acquisition_description/encoding/trajectoryDescription
  * svk_data_acquisition_description/encoding/trajectoryDescription/identifier
+ * svk_data_acquisition_description/encoding/trajectoryDescription/dimensions
  * svk_data_acquisition_description/encoding/trajectoryDescription/comment
  * svk_data_acquisition_description/encoding/encodedSpace
  * svk_data_acquisition_description/encoding/encodedSpace/matrixSize
@@ -250,6 +395,8 @@ void svkDataAcquisitionDescriptionXML::InitializeEmptyXMLFile()
             encodingElem, "trajectoryDescription" , "" );
     vtkXMLDataElement* trajectoryIDElem = svkXMLUtils::CreateNestedXMLDataElement( 
             trajectoryDescElem, "identifier" , "" );
+    vtkXMLDataElement* trajectoryDimensionElem = svkXMLUtils::CreateNestedXMLDataElement(
+            trajectoryDescElem, "dimensions" , "" );
     vtkXMLDataElement* trajectoryCommentElem = svkXMLUtils::CreateNestedXMLDataElement( 
             trajectoryDescElem, "comment" , "" );
     vtkXMLDataElement* spaceElem = svkXMLUtils::CreateNestedXMLDataElement( 
@@ -276,6 +423,7 @@ void svkDataAcquisitionDescriptionXML::InitializeEmptyXMLFile()
     trajectoryElem->Delete();
     trajectoryDescElem->Delete();
     trajectoryIDElem->Delete();
+    trajectoryDimensionElem->Delete();
     trajectoryCommentElem->Delete();
     spaceElem->Delete();
     matrixElem->Delete();
@@ -433,6 +581,7 @@ void svkDataAcquisitionDescriptionXML::SetTrajectoryParameter( string type, stri
                 valueElem = paramElem->FindNestedElementWithName("value");
                 if( valueElem != NULL ) {
                     valueElem->SetCharacterData(value.c_str(), value.size());
+                    errorFound = false;
                 } else {
                     cout << "ERROR: " << type << " " << name << " does not contain a value tag." << endl;
                     errorFound = true;
@@ -542,10 +691,19 @@ vtkXMLDataElement* svkDataAcquisitionDescriptionXML::FindNestedElementWithPath( 
 {
     vtkXMLDataElement* elem = NULL;
     elem = svkXMLUtils::FindNestedElementWithPath(this->dataAcquisitionDescriptionXML, xmlPath );
-    if( elem == NULL ) {
-        cout << "ERROR: Could not locate element at path: " << xmlPath << endl;
-    }
     return elem;
+}
+
+
+/*!
+ *
+ * @param parentPath
+ * @param elementName
+ * @return
+ */
+vtkXMLDataElement* svkDataAcquisitionDescriptionXML::FindOrCreateNestedElementWithPath( string parentPath, string elementName)
+{
+    return svkXMLUtils::FindOrCreateNestedElementWithPath(this->dataAcquisitionDescriptionXML, parentPath, elementName);
 }
 
 
@@ -573,14 +731,75 @@ const char * svkDataAcquisitionDescriptionXML::GetDataWithPath( const char* xmlP
  */
 int svkDataAcquisitionDescriptionXML::GetIntByIndexWithParentPath( int index, const char* parentPath )
 {
-    string data = this->GetDataWithPath( parentPath );
     vtkXMLDataElement* parentElement = svkXMLUtils::FindNestedElementWithPath(this->GetRootXMLDataElement(), parentPath);
     vtkXMLDataElement* element = parentElement->GetNestedElement(index);
-    data = element->GetCharacterData();
+    string data = element->GetCharacterData();
     if( data.compare("") != 0 ){
         return svkTypeUtils::StringToInt(data);
     }
     return -1;
+}
+
+
+/*!
+ *
+ * @param elementPath
+ * @return
+ */
+int svkDataAcquisitionDescriptionXML::GetIntWithPath( const char* elementPath )
+{
+    string data = this->GetDataWithPath( elementPath );
+    if( data.compare("") != 0 ){
+        return svkTypeUtils::StringToInt(data);
+    }
+    return -1;
+}
+
+
+/*!
+ *
+ * @param parentPath
+ * @param elementName
+ * @param value
+ */
+void svkDataAcquisitionDescriptionXML::SetIntWithPath( const char* parentPath, const char* elementName, int value)
+{
+    vtkXMLDataElement* elem = this->FindOrCreateNestedElementWithPath( parentPath, elementName );
+    string data = svkTypeUtils::IntToString(value);
+    if( elem != NULL ){
+        elem->SetCharacterData(data.c_str(), data.size());
+    }
+}
+
+
+/*!
+ *
+ * @param elementPath
+ * @return
+ */
+float svkDataAcquisitionDescriptionXML::GetFloatWithPath( const char* elementPath )
+{
+    string data = this->GetDataWithPath( elementPath );
+    if( data.compare("") != 0 ){
+        return svkTypeUtils::StringToFloat(data);
+    }
+    return -1;
+}
+
+
+/*!
+ *
+ * @param parentPath
+ * @param elementName
+ * @param value
+ */
+void svkDataAcquisitionDescriptionXML::SetFloatWithPath( const char* parentPath, const char* elementName, float value)
+{
+    vtkXMLDataElement* elem = this->FindOrCreateNestedElementWithPath( parentPath, elementName );
+    string data = svkTypeUtils::DoubleToString(value);
+    if( elem != NULL ){
+        elem->SetCharacterData(data.c_str(), data.size());
+    }
 }
 
 
@@ -592,11 +811,32 @@ int svkDataAcquisitionDescriptionXML::GetIntByIndexWithParentPath( int index, co
  */
 const char * svkDataAcquisitionDescriptionXML::GetDataByIndexWithParentPath( int index, const char* parentPath )
 {
+    vtkXMLDataElement* element = this->GetNestedElementByIndexWithParentPath(index, parentPath);
+    if( element != NULL ) {
+        return element->GetName();
+    }
+    return NULL;
+}
+
+
+/*!
+ *
+ * @param index
+ * @param parentPath
+ * @return
+ */
+vtkXMLDataElement* svkDataAcquisitionDescriptionXML::GetNestedElementByIndexWithParentPath( int index, const char* parentPath )
+{
+    vtkXMLDataElement* element = NULL;
     string data = this->GetDataWithPath( parentPath );
     vtkXMLDataElement* parentElement = svkXMLUtils::FindNestedElementWithPath(this->GetRootXMLDataElement(), parentPath);
-    vtkXMLDataElement* element = parentElement->GetNestedElement(index);
-    return element->GetName();
+    if( parentElement != NULL ) {
+        element = parentElement->GetNestedElement(index);
+    }
+
+    return element;
 }
+
 
 /*!
  *  Sets the character data for an xml element. Reports an error and returns
@@ -613,6 +853,22 @@ int svkDataAcquisitionDescriptionXML::SetDataWithPath( const char* xmlPath, cons
         return -1;
     } else {
         return 0;
+    }
+
+}
+
+
+/*!
+ *
+ * @param parentPath
+ * @param elementName
+ * @param value
+ */
+void svkDataAcquisitionDescriptionXML::SetDataWithPath( const char* parentPath, const char* elementName, string value)
+{
+    vtkXMLDataElement* elem = this->FindOrCreateNestedElementWithPath( parentPath, elementName );
+    if( elem != NULL ){
+        elem->SetCharacterData(value.c_str(), value.size());
     }
 }
 
@@ -691,16 +947,16 @@ vtkXMLDataElement* svkDataAcquisitionDescriptionXML::GetRootXMLDataElement()
  *
  * @return
  */
-svkEPSIReorder::EPSIType svkDataAcquisitionDescriptionXML::GetEPSIType()
+EPSIType svkDataAcquisitionDescriptionXML::GetEPSIType()
 {
     string epsiTypeFromDad = this->GetDataWithPath("/encoding/trajectoryDescription/epsiEncoding/epsiType");
-    svkEPSIReorder::EPSIType epsiType = svkEPSIReorder::UNDEFINED_EPSI_TYPE;
+    EPSIType epsiType = UNDEFINED_EPSI_TYPE;
     if( epsiTypeFromDad.compare("SYMMETRIC") == 0 ){
-        epsiType = svkEPSIReorder::SYMMETRIC;
+        epsiType = SYMMETRIC;
     } else if ( epsiTypeFromDad.compare("FLYBACK") == 0 ) {
-        epsiType = svkEPSIReorder::FLYBACK;
+        epsiType = FLYBACK;
     } else if (epsiTypeFromDad.compare("INTERLEAVED") == 0 ) {
-        epsiType = svkEPSIReorder::INTERLEAVED;
+        epsiType = INTERLEAVED;
     }
 
     return epsiType;
@@ -715,6 +971,298 @@ const char* svkDataAcquisitionDescriptionXML::GetEPSITypeString()
 {
     string epsiTypeFromDad = this->GetDataWithPath("/encoding/trajectoryDescription/epsiEncoding/epsiType");
     return epsiTypeFromDad.c_str();
+}
+
+
+/*!
+ *
+ * @param numberOfInterleaves
+ */
+void svkDataAcquisitionDescriptionXML::SetEPSINumberOfInterleaves( int numberOfInterleaves )
+{
+    this->SetIntWithPath("/encoding/trajectoryDescription/epsiEncoding", "numInterleaves", numberOfInterleaves);
+}
+
+
+/*!
+ *
+ * @return
+ */
+int svkDataAcquisitionDescriptionXML::GetEPSINumberOfInterleaves( )
+{
+    return this->GetIntWithPath("/encoding/trajectoryDescription/epsiEncoding/numInterleaves");
+}
+
+
+/*!
+ *
+ * @param gradientAmplitude
+ * @param lobe
+ */
+void svkDataAcquisitionDescriptionXML::SetEPSIGradientAmplitude( float gradientAmplitude, enum EPSILobe lobe )
+{
+    string element = "";
+    if( lobe == ODD ) {
+        element = "gradientAmplitudeOddMTM";
+    } else if( lobe == EVEN ) {
+        element = "gradientAmplitudeEvenMTM";
+    } else {
+        cout << "ERROR: EPSI lobe must be either EVEN or ODD." << endl;
+        return;
+    }
+    this->SetFloatWithPath("/encoding/trajectoryDescription/epsiEncoding", element.c_str(), gradientAmplitude);
+
+}
+
+
+/*!
+ *
+ * @param lobe
+ * @return
+ */
+float svkDataAcquisitionDescriptionXML::GetEPSIGradientAmplitude( enum EPSILobe lobe )
+{
+    string path = "/encoding/trajectoryDescription/epsiEncoding/";
+    if( lobe == ODD ) {
+        path.append("gradientAmplitudeOddMTM");
+    } else if( lobe == EVEN ) {
+        path.append("gradientAmplitudeEvenMTM");
+    } else {
+        cout << "ERROR: EPSI lobe must be either EVEN or ODD." << endl;
+        return 0;
+    }
+    return this->GetFloatWithPath(path.c_str());
+
+}
+
+
+/*!
+ *
+ * @param rampDuration
+ * @param lobe
+ */
+void svkDataAcquisitionDescriptionXML::SetEPSIRampDuration( float rampDuration, enum EPSILobe lobe )
+{
+    string element = "";
+    if( lobe == ODD ) {
+        element = "rampDurationOddMs";
+    } else if( lobe == EVEN ) {
+        element = "rampDurationEvenMs";
+    } else {
+        cout << "ERROR: EPSI lobe must be either EVEN or ODD." << endl;
+        return;
+    }
+    this->SetFloatWithPath("/encoding/trajectoryDescription/epsiEncoding", element.c_str(), rampDuration);
+
+}
+
+
+/*!
+ *
+ * @param lobe
+ * @return
+ */
+float svkDataAcquisitionDescriptionXML::GetEPSIRampDuration( enum EPSILobe lobe )
+{
+    string path = "/encoding/trajectoryDescription/epsiEncoding/";
+    if( lobe == ODD ) {
+        path.append("rampDurationOddMs");
+    } else if( lobe == EVEN ) {
+        path.append("rampDurationEvenMs");
+    } else {
+        cout << "ERROR: EPSI lobe must be either EVEN or ODD." << endl;
+        return 0;
+    }
+    return this->GetFloatWithPath(path.c_str());
+
+}
+
+
+/*!
+ *
+ * @param plateauDuration
+ * @param lobe
+ */
+void svkDataAcquisitionDescriptionXML::SetEPSIPlateauDuration( float plateauDuration, enum EPSILobe lobe )
+{
+    string element = "";
+    if( lobe == ODD ) {
+        element = "plateauDurationOddMTM";
+    } else if( lobe == EVEN ) {
+        element = "plateauDurationEvenMTM";
+    } else {
+        cout << "ERROR: EPSI lobe must be either EVEN or ODD." << endl;
+        return;
+    }
+    this->SetFloatWithPath("/encoding/trajectoryDescription/epsiEncoding", element.c_str(), plateauDuration);
+
+}
+
+
+/*!
+ *
+ * @param lobe
+ * @return
+ */
+float svkDataAcquisitionDescriptionXML::GetEPSIPlateauDuration( enum EPSILobe lobe )
+{
+    string path = "/encoding/trajectoryDescription/epsiEncoding/";
+    if( lobe == ODD ) {
+        path.append("plateauDurationOddMTM");
+    } else if( lobe == EVEN ) {
+        path.append("plateauDurationEvenMTM");
+    } else {
+        cout << "ERROR: EPSI lobe must be either EVEN or ODD." << endl;
+        return 0;
+    }
+    return this->GetFloatWithPath(path.c_str());
+
+}
+
+
+/*!
+ *
+ * @param numberOfLobes
+ * @param lobe
+ */
+void svkDataAcquisitionDescriptionXML::SetEPSINumberOfLobes( int numberOfLobes, enum EPSILobe lobe )
+{
+    string element = "";
+    if( lobe == ODD ) {
+        element = "numberOfLobesOddMTM";
+    } else if( lobe == EVEN ) {
+        element = "numberOfLobesEvenMTM";
+    } else {
+        cout << "ERROR: EPSI lobe must be either EVEN or ODD." << endl;
+        return;
+    }
+    this->SetIntWithPath("/encoding/trajectoryDescription/epsiEncoding", element.c_str(), numberOfLobes);
+
+}
+
+
+/*!
+ *
+ * @param lobe
+ * @return
+ */
+int svkDataAcquisitionDescriptionXML::GetEPSINumberOfLobes( enum EPSILobe lobe )
+{
+    string path = "/encoding/trajectoryDescription/epsiEncoding/";
+    if( lobe == ODD ) {
+        path.append("numberOfLobesOddMTM");
+    } else if( lobe == EVEN ) {
+        path.append("numberOfLobesEvenMTM");
+    } else {
+        cout << "ERROR: EPSI lobe must be either EVEN or ODD." << endl;
+        return 0;
+    }
+    return this->GetIntWithPath(path.c_str());
+
+}
+
+
+/*!
+ *
+ * @param sampleSpacing
+ */
+void svkDataAcquisitionDescriptionXML::SetEPSISampleSpacing( float sampleSpacing )
+{
+    this->SetFloatWithPath("/encoding/trajectoryDescription/epsiEncoding", "sampleSpacingTimeMs", sampleSpacing);
+}
+
+
+/*!
+ *
+ * @return
+ */
+float svkDataAcquisitionDescriptionXML::GetEPSISampleSpacing( )
+{
+    string path = "/encoding/trajectoryDescription/epsiEncoding/sampleSpacingTimeMs";
+    return this->GetFloatWithPath(path.c_str());
+}
+
+
+/*!
+ *
+ * @param acquisitionDelay
+ */
+void svkDataAcquisitionDescriptionXML::SetEPSIAcquisitionDelay( float acquisitionDelay )
+{
+    this->SetFloatWithPath("/encoding/trajectoryDescription/epsiEncoding", "acquisitionDelayTimeMs", acquisitionDelay);
+}
+
+
+/*!
+ *
+ * @return
+ */
+float svkDataAcquisitionDescriptionXML::GetEPSIAcquisitionDelay( ) {
+    string path = "/encoding/trajectoryDescription/epsiEncoding/acquisitionDelayTimeMs";
+    return this->GetFloatWithPath(path.c_str());
+}
+
+
+/*!
+ *
+ * @param echoDelay
+ */
+void svkDataAcquisitionDescriptionXML::SetEPSIEchoDelay( float echoDelay )
+{
+    this->SetFloatWithPath("/encoding/trajectoryDescription/epsiEncoding", "echoDelayTimeMs", echoDelay);
+}
+
+
+/*!
+ *
+ * @return
+ */
+float svkDataAcquisitionDescriptionXML::GetEPSIEchoDelay( ) {
+    string path = "/encoding/trajectoryDescription/epsiEncoding/echoDelayTimeMs";
+    return this->GetFloatWithPath(path.c_str());
+}
+
+
+/*!
+ *
+ * @param gradientAxis
+ */
+void svkDataAcquisitionDescriptionXML::SetEPSIGradientAxis( int gradientAxis )
+{
+    vtkXMLDataElement* element = this->GetNestedElementByIndexWithParentPath(gradientAxis - 1, "encoding/trajectoryDescription/dimensions");
+    string idName = element->GetAttribute("id");
+    this->SetDataWithPath("/encoding/trajectoryDescription/epsiEncoding", "gradientAxis", idName.c_str());
+}
+
+
+/*!
+ *
+ * @return
+ */
+string svkDataAcquisitionDescriptionXML::GetEPSIGradientAxisId( )
+{
+    return this->GetDataWithPath( "/encoding/trajectoryDescription/epsiEncoding/gradientAxis" );
+}
+
+
+/*!
+ *
+ * @return
+ */
+int svkDataAcquisitionDescriptionXML::GetEPSIGradientAxisIndex( )
+{
+
+    vtkXMLDataElement* dimensionsElement = this->FindNestedElementWithPath("encoding/trajectoryDescription/dimensions");
+    int numberOfDimensions = this->GetTrajectoryNumberOfDimensions();
+    for( int i = 0; i < numberOfDimensions; i++ ) {
+        vtkXMLDataElement* element = dimensionsElement->GetNestedElement(i);
+        string idName = element->GetAttribute("id");
+        if( idName.compare( this->GetEPSIGradientAxisId() ) == 0) {
+            return i + 1;
+        }
+
+    }
+    return -1;
 }
 
 
@@ -773,6 +1321,17 @@ int svkDataAcquisitionDescriptionXML::GetEncodedMatrixSizeNumberOfDimensions()
     return parentElement->GetNumberOfNestedElements();
 }
 
+
+/*!
+ *
+ * @return
+ */
+svkCString GetEmptySvkCString()
+{
+    svkCString data;
+    data.c_str[0] = '\0';
+    return data;
+}
 
 
 /*!
@@ -853,14 +1412,14 @@ int svkDataAcquisitionDescriptionXML_WriteXMLFile(const char* filepath, void* xm
  * \param path the xpath of the requested XML element
  * \return the contents of the requested element
  */
-const char* svkDataAcquisitionDescriptionXML_GetDataWithPath( void* xml, const char* path )
+svkCString svkDataAcquisitionDescriptionXML_GetDataWithPath( void* xml, const char* path )
 {
+    svkCString data;
     if( xml != NULL ) {
-        return ((svkDataAcquisitionDescriptionXML*)xml)->GetDataWithPath( path );
-    } else {
-        printf(NULL_XML_ERROR);
-        return NULL;
+        string stringData = ((svkDataAcquisitionDescriptionXML*)xml)->GetDataWithPath( path );
+        strcpy(data.c_str, stringData.c_str());
     }
+    return data;
 }
 
 
@@ -979,14 +1538,16 @@ void svkDataAcquisitionDescriptionXML_SetTrajectory(const char* type, const char
  * \param xml a void pointer to the svk::svkDataAcquisitionDescriptionXML object
  * \return the contents of the encoding/trajectory element
  */
-const char* svkDataAcquisitionDescriptionXML_GetTrajectoryType(void* xml)
+svkCString svkDataAcquisitionDescriptionXML_GetTrajectoryType(void* xml)
 {
+    svkCString data;
     if( xml != NULL ) {
-        return (((svkDataAcquisitionDescriptionXML*)xml)->GetTrajectoryType( )).c_str();
+        string stringData = (((svkDataAcquisitionDescriptionXML*)xml)->GetTrajectoryType( )).c_str();
+        strcpy(data.c_str, stringData.c_str());
     } else {
         printf(NULL_XML_ERROR);
-        return NULL;
     }
+    return data;
 }
 
 
@@ -995,13 +1556,33 @@ const char* svkDataAcquisitionDescriptionXML_GetTrajectoryType(void* xml)
  * \param xml a void pointer to the svk::svkDataAcquisitionDescriptionXML object
  * \return the contents of the encoding/trajectoryDescription/identifier element
  */
-const char* svkDataAcquisitionDescriptionXML_GetTrajectoryID(void* xml)
+svkCString svkDataAcquisitionDescriptionXML_GetTrajectoryID(void* xml)
 {
+    svkCString data;
     if( xml != NULL ) {
-        return (((svkDataAcquisitionDescriptionXML*)xml)->GetTrajectoryID( )).c_str();
+        string stringData = (((svkDataAcquisitionDescriptionXML*)xml)->GetTrajectoryID( )).c_str();
+        strcpy(data.c_str, stringData.c_str());
     } else {
         printf(NULL_XML_ERROR);
-        return NULL;
+    }
+    return data;
+}
+
+
+/*!
+ *
+ * @param id
+ * @param logical
+ * @param description
+ * @param xml
+ */
+void svkDataAcquisitionDescriptionXML_AddTrajectoryDimension(const char* id, const char* logical,
+                                                                          const char* description, void *xml)
+{
+    if( xml != NULL ) {
+        ((svkDataAcquisitionDescriptionXML*)xml)->AddTrajectoryDimension( id, logical, description );
+    } else {
+        printf(NULL_XML_ERROR);
     }
 }
 
@@ -1011,13 +1592,440 @@ const char* svkDataAcquisitionDescriptionXML_GetTrajectoryID(void* xml)
  * \param xml a void pointer to the svk::svkDataAcquisitionDescriptionXML object
  * \return the contents of the encoding/trajectoryDescription/comment element
  */
-const char* svkDataAcquisitionDescriptionXML_GetTrajectoryComment(void* xml)
+svkCString svkDataAcquisitionDescriptionXML_GetTrajectoryComment(void* xml)
 {
+    svkCString data;
     if( xml != NULL ) {
-        return (((svkDataAcquisitionDescriptionXML*)xml)->GetTrajectoryComment( )).c_str();
+        string stringData = (((svkDataAcquisitionDescriptionXML*)xml)->GetTrajectoryComment( )).c_str();
+        strcpy(data.c_str, stringData.c_str());
     } else {
         printf(NULL_XML_ERROR);
-        return NULL;
+    }
+    return data;
+}
+
+
+/*!
+ *
+ * @param xml
+ * @return
+ */
+int svkDataAcquisitionDescriptionXML_GetTrajectoryNumberOfDimensions(void *xml)
+{
+    if( xml != NULL ) {
+        return ((svkDataAcquisitionDescriptionXML*)xml)->GetTrajectoryNumberOfDimensions();
+    } else {
+        printf(NULL_XML_ERROR);
+        return -1;
+    }
+}
+
+
+/*!
+ *
+ * @param index
+ * @param xml
+ * @return
+ */
+struct svkCString svkDataAcquisitionDescriptionXML_GetTrajectoryDimensionId(int index, void *xml) {
+    svkCString data = GetEmptySvkCString();
+    if( xml != NULL ) {
+        string stringData = ((svkDataAcquisitionDescriptionXML*)xml)->GetTrajectoryDimensionId(index);
+        strcpy(data.c_str, stringData.c_str());
+    } else {
+        printf(NULL_XML_ERROR);
+    }
+    return data;
+}
+
+
+/*!
+ *
+ * @param index
+ * @param xml
+ * @return
+ */
+struct svkCString svkDataAcquisitionDescriptionXML_GetTrajectoryDimensionLogical(int index, void *xml) {
+
+    svkCString data = GetEmptySvkCString();
+    if( xml != NULL ) {
+        string stringData = ((svkDataAcquisitionDescriptionXML*)xml)->GetTrajectoryDimensionLogical(index);
+        strcpy(data.c_str, stringData.c_str());
+    } else {
+        printf(NULL_XML_ERROR);
+    }
+    return data;
+
+}
+
+
+/*!
+ *
+ * @param index
+ * @param xml
+ * @return
+ */
+struct svkCString svkDataAcquisitionDescriptionXML_GetTrajectoryDimensionDescription(int index, void *xml) {
+    svkCString data = GetEmptySvkCString();
+    if( xml != NULL ) {
+        string stringData = ((svkDataAcquisitionDescriptionXML*)xml)->GetTrajectoryDimensionDescription(index);
+        strcpy(data.c_str, stringData.c_str());
+    } else {
+        printf(NULL_XML_ERROR);
+    }
+    return data;
+}
+
+
+/*!
+ *
+ * @param xml
+ */
+void svkDataAcquisitionDescriptionXML_SetEPSITypeToFlyback(void* xml) {
+    svkDataAcquisitionDescriptionXML_SetEPSIType( FLYBACK, xml );
+}
+
+
+/*!
+ *
+ * @param xml
+ */
+void svkDataAcquisitionDescriptionXML_SetEPSITypeToSymmetric(void* xml) {
+    svkDataAcquisitionDescriptionXML_SetEPSIType( SYMMETRIC, xml );
+}
+
+
+/*!
+ *
+ * @param type
+ * @param xml
+ */
+void svkDataAcquisitionDescriptionXML_SetEPSIType( enum EPSIType type, void* xml) {
+    if( xml != NULL ) {
+        ((svkDataAcquisitionDescriptionXML*)xml)->SetEPSIType( type );
+    } else {
+        printf(NULL_XML_ERROR);
+    }
+}
+
+
+/*!
+ *
+ * @param xml
+ * @return
+ */
+enum EPSIType svkDataAcquisitionDescriptionXML_GetEPSIType(void* xml)
+{
+    if( xml != NULL ) {
+        return ((svkDataAcquisitionDescriptionXML*)xml)->GetEPSIType( );
+    } else {
+        printf(NULL_XML_ERROR);
+    }
+    return UNDEFINED_EPSI_TYPE;
+}
+
+
+/*!
+ *
+ * @param numberOfInterleaves
+ * @param xml
+ */
+void svkDataAcquisitionDescriptionXML_SetEPSINumberOfInterleaves( int numberOfInterleaves, void* xml)
+{
+    if( xml != NULL ) {
+        return ((svkDataAcquisitionDescriptionXML*)xml)->SetEPSINumberOfInterleaves( numberOfInterleaves );
+    } else {
+        printf(NULL_XML_ERROR);
+    }
+}
+
+
+/*!
+ *
+ * @param xml
+ * @return
+ */
+int svkDataAcquisitionDescriptionXML_GetEPSINumberOfInterleaves( void* xml)
+{
+    if( xml != NULL ) {
+        return ((svkDataAcquisitionDescriptionXML*)xml)->GetEPSINumberOfInterleaves( );
+    } else {
+        printf(NULL_XML_ERROR);
+        return -1;
+    }
+}
+
+
+/*!
+ *
+ * @param amplitude
+ * @param lobe
+ * @param xml
+ */
+void svkDataAcquisitionDescriptionXML_SetEPSIGradientAmplitude(float amplitude, enum EPSILobe lobe, void* xml)
+{
+    if( xml != NULL ) {
+        return ((svkDataAcquisitionDescriptionXML*)xml)->SetEPSIGradientAmplitude( amplitude, lobe );
+    } else {
+        printf(NULL_XML_ERROR);
+    }
+}
+
+
+/*!
+ *
+ * @param lobe
+ * @param xml
+ * @return
+ */
+float svkDataAcquisitionDescriptionXML_GetEPSIGradientAmplitude(enum EPSILobe lobe, void *xml)
+{
+    if( xml != NULL ) {
+        return ((svkDataAcquisitionDescriptionXML*)xml)->GetEPSIGradientAmplitude( lobe );
+    } else {
+        printf(NULL_XML_ERROR);
+        return 0;
+    }
+}
+
+
+/*!
+ *
+ * @param duration
+ * @param lobe
+ * @param xml
+ */
+void svkDataAcquisitionDescriptionXML_SetEPSIRampDuration(float duration, enum EPSILobe lobe, void* xml)
+{
+    if( xml != NULL ) {
+        return ((svkDataAcquisitionDescriptionXML*)xml)->SetEPSIRampDuration( duration, lobe );
+    } else {
+        printf(NULL_XML_ERROR);
+    }
+}
+
+
+/*!
+ *
+ * @param lobe
+ * @param xml
+ * @return
+ */
+float svkDataAcquisitionDescriptionXML_GetEPSIRampDuration(enum EPSILobe lobe, void *xml)
+{
+    if( xml != NULL ) {
+        return ((svkDataAcquisitionDescriptionXML*)xml)->GetEPSIRampDuration( lobe );
+    } else {
+        printf(NULL_XML_ERROR);
+        return 0;
+    }
+}
+
+
+/*!
+ *
+ * @param duration
+ * @param lobe
+ * @param xml
+ */
+void svkDataAcquisitionDescriptionXML_SetEPSIPlateauDuration(float duration, enum EPSILobe lobe, void* xml)
+{
+    if( xml != NULL ) {
+        return ((svkDataAcquisitionDescriptionXML*)xml)->SetEPSIPlateauDuration( duration, lobe );
+    } else {
+        printf(NULL_XML_ERROR);
+    }
+}
+
+
+/*!
+ *
+ * @param lobe
+ * @param xml
+ * @return
+ */
+float svkDataAcquisitionDescriptionXML_GetEPSIPlateauDuration(enum EPSILobe lobe, void *xml)
+{
+    if( xml != NULL ) {
+        return ((svkDataAcquisitionDescriptionXML*)xml)->GetEPSIPlateauDuration( lobe );
+    } else {
+        printf(NULL_XML_ERROR);
+        return 0;
+    }
+}
+
+
+/*!
+ *
+ * @param numberOfLobes
+ * @param lobe
+ * @param xml
+ */
+void svkDataAcquisitionDescriptionXML_SetEPSINumberOfLobes(int numberOfLobes, enum EPSILobe lobe, void* xml)
+{
+    if( xml != NULL ) {
+        return ((svkDataAcquisitionDescriptionXML*)xml)->SetEPSINumberOfLobes( numberOfLobes, lobe );
+    } else {
+        printf(NULL_XML_ERROR);
+    }
+}
+
+
+/*!
+ *
+ * @param lobe
+ * @param xml
+ * @return
+ */
+float svkDataAcquisitionDescriptionXML_GetEPSINumberOfLobes(enum EPSILobe lobe, void *xml)
+{
+    if( xml != NULL ) {
+        return ((svkDataAcquisitionDescriptionXML*)xml)->GetEPSINumberOfLobes( lobe );
+    } else {
+        printf(NULL_XML_ERROR);
+        return 0;
+    }
+}
+
+
+/*!
+ *
+ * @param sampleSpacing
+ * @param xml
+ */
+void svkDataAcquisitionDescriptionXML_SetEPSISampleSpacing(float sampleSpacing, void* xml)
+{
+    if( xml != NULL ) {
+        return ((svkDataAcquisitionDescriptionXML*)xml)->SetEPSISampleSpacing( sampleSpacing );
+    } else {
+        printf(NULL_XML_ERROR);
+    }
+}
+
+
+/*!
+ *
+ * @param xml
+ * @return
+ */
+float svkDataAcquisitionDescriptionXML_GetEPSISampleSpacing(void *xml)
+{
+    if( xml != NULL ) {
+        return ((svkDataAcquisitionDescriptionXML*)xml)->GetEPSISampleSpacing();
+    } else {
+        printf(NULL_XML_ERROR);
+        return 0;
+    }
+}
+
+
+/*!
+ *
+ * @param acquisitionDelay
+ * @param xml
+ */
+void svkDataAcquisitionDescriptionXML_SetEPSIAcquisitionDelay(float acquisitionDelay, void* xml)
+{
+    if( xml != NULL ) {
+        return ((svkDataAcquisitionDescriptionXML*)xml)->SetEPSIAcquisitionDelay( acquisitionDelay );
+    } else {
+        printf(NULL_XML_ERROR);
+    }
+}
+
+
+/*!
+ *
+ * @param xml
+ * @return
+ */
+float svkDataAcquisitionDescriptionXML_GetEPSIAcquisitionDelay(void *xml)
+{
+    if( xml != NULL ) {
+        return ((svkDataAcquisitionDescriptionXML*)xml)->GetEPSIAcquisitionDelay();
+    } else {
+        printf(NULL_XML_ERROR);
+        return 0;
+    }
+}
+
+
+/*!
+ *
+ * @param echoDelay
+ * @param xml
+ */
+void svkDataAcquisitionDescriptionXML_SetEPSIEchoDelay(float echoDelay, void* xml)
+{
+    if( xml != NULL ) {
+        return ((svkDataAcquisitionDescriptionXML*)xml)->SetEPSIEchoDelay( echoDelay );
+    } else {
+        printf(NULL_XML_ERROR);
+    }
+}
+
+
+/*!
+ *
+ * @param xml
+ * @return
+ */
+float svkDataAcquisitionDescriptionXML_GetEPSIEchoDelay(void *xml)
+{
+    if( xml != NULL ) {
+        return ((svkDataAcquisitionDescriptionXML*)xml)->GetEPSIEchoDelay();
+    } else {
+        printf(NULL_XML_ERROR);
+        return 0;
+    }
+}
+
+
+/*!
+ *
+ * @param gradientAxis
+ * @param xml
+ */
+void svkDataAcquisitionDescriptionXML_SetEPSIGradientAxis(int gradientAxis, void* xml)
+{
+    if( xml != NULL ) {
+        return ((svkDataAcquisitionDescriptionXML*)xml)->SetEPSIGradientAxis( gradientAxis );
+    } else {
+        printf(NULL_XML_ERROR);
+    }
+}
+
+
+/*!
+ *
+ * @param xml
+ * @return
+ */
+struct svkCString svkDataAcquisitionDescriptionXML_GetEPSIGradientAxisId(void *xml)
+{
+    svkCString data = GetEmptySvkCString();
+    if( xml != NULL ) {
+        string stringData = ((svkDataAcquisitionDescriptionXML*)xml)->GetEPSIGradientAxisId();
+        strcpy(data.c_str, stringData.c_str());
+    } else {
+        printf(NULL_XML_ERROR);
+    }
+    return data;
+}
+
+
+/*!
+ *
+ * @param xml
+ * @return
+ */
+int svkDataAcquisitionDescriptionXML_GetEPSIGradientAxisIndex(void *xml)
+{
+    if( xml != NULL ) {
+        return ((svkDataAcquisitionDescriptionXML*)xml)->GetEPSIGradientAxisIndex();
+    } else {
+        printf(NULL_XML_ERROR);
+        return -0;
     }
 }
 
@@ -1147,12 +2155,15 @@ int svkDataAcquisitionDescriptionXML_GetEncodedMatrixSizeDimensionValue(int inde
  * @param xml
  * @return
  */
-const char* svkDataAcquisitionDescriptionXML_GetEncodedMatrixSizeDimensionName(int index, void* xml)
+svkCString svkDataAcquisitionDescriptionXML_GetEncodedMatrixSizeDimensionName(int index, void* xml)
 {
+    svkCString data = GetEmptySvkCString();
     if( xml != NULL ) {
-        return ((svkDataAcquisitionDescriptionXML*)xml)->GetEncodedMatrixSizeDimensionName(index);
+        string stringData = ((svkDataAcquisitionDescriptionXML*)xml)->GetEncodedMatrixSizeDimensionName(index);
+        strcpy(data.c_str, stringData.c_str());
     } else {
         printf(NULL_XML_ERROR);
-        return NULL;
     }
+    return data;
 }
+

--- a/libs/src/svkDataAcquisitionDescriptionXML.h
+++ b/libs/src/svkDataAcquisitionDescriptionXML.h
@@ -51,6 +51,21 @@
  *
  */
 
+enum EPSIType
+{
+    UNDEFINED_EPSI_TYPE,
+    SYMMETRIC,
+    FLYBACK,
+    INTERLEAVED
+
+};
+
+enum EPSILobe
+{
+    EVEN,
+    ODD,
+    UNDEFINED
+};
 #ifdef __cplusplus
 
 #include <vtkObject.h>
@@ -107,11 +122,21 @@ class svkDataAcquisitionDescriptionXML: public vtkObject
         void                        SetVerbose( bool isVerbose );     
         int                         GetXMLVersion(); 
         vtkXMLDataElement*          FindNestedElementWithPath( string xmlPath);
+        vtkXMLDataElement*          FindOrCreateNestedElementWithPath( string parentPath, string elementName);
+
         const char*                 GetDataWithPath( const char* xmlPath );
         int                         GetIntByIndexWithParentPath( int index, const char* parentPath );
+        int                         GetIntWithPath( const char* elementPath );
+        void                        SetIntWithPath( const char* parentPath, const char* elmentName, int value );
+        float                       GetFloatWithPath( const char* elementPath );
+        void                        SetFloatWithPath( const char* parentPath, const char* elmentName, float value );
+
         const char*                 GetDataByIndexWithParentPath( int index, const char* parentPath );
+        vtkXMLDataElement*          GetNestedElementByIndexWithParentPath( int index, const char* parentPath );
 
         int                         SetDataWithPath( const char* xmlPath, const char* value );
+        void                        SetDataWithPath( const char* parentPath, const char* elmentName, string value );
+
         vtkXMLDataElement*          AddElementWithParentPath( const char* xmlPath, const char* name );
         int                         RemoveElementWithParentPath( const char* xmlPath, const char* name );
 
@@ -129,13 +154,48 @@ class svkDataAcquisitionDescriptionXML: public vtkObject
         void                        SetTrajectoryComment( string comment );
         string                      GetTrajectoryComment( );
 
+        int                         GetTrajectoryNumberOfDimensions();
+        void                        AddTrajectoryDimension(string id, string logical, string description);
+        string                      GetTrajectoryDimensionId(int index);
+        string                      GetTrajectoryDimensionLogical(int index);
+        string                      GetTrajectoryDimensionDescription(int index);
+        void                        SetEPSIType(EPSIType type);
+
+        void                        SetEPSINumberOfInterleaves( int numberOfInterleaves );
+        int                         GetEPSINumberOfInterleaves( );
+
+        void                        SetEPSIGradientAmplitude( float gradientAmplitude, EPSILobe lobe);
+        float                       GetEPSIGradientAmplitude( EPSILobe lobe );
+        
+        void                        SetEPSIRampDuration( float rampDuration, EPSILobe lobe);
+        float                       GetEPSIRampDuration( EPSILobe lobe );
+
+        void                        SetEPSIPlateauDuration( float plateauDuration, EPSILobe lobe);
+        float                       GetEPSIPlateauDuration( EPSILobe lobe );
+
+        void                        SetEPSINumberOfLobes( int numberOfLobes, EPSILobe lobe);
+        int                         GetEPSINumberOfLobes( EPSILobe lobe );
+
+        void                        SetEPSISampleSpacing( float sampleSpacing );
+        float                       GetEPSISampleSpacing( );
+
+        void                        SetEPSIAcquisitionDelay( float acquisitionDelay );
+        float                       GetEPSIAcquisitionDelay( );
+        
+        void                        SetEPSIEchoDelay( float echoDelay );
+        float                       GetEPSIEchoDelay( );
+        
+        void                        SetEPSIGradientAxis( int dimensionIndex );
+        string                      GetEPSIGradientAxisId( );
+        int                         GetEPSIGradientAxisIndex( );
+
         void                        SetTrajectoryParameter( string name, long value  );
         long                        GetTrajectoryLongParameter( string name );
 
         void                        SetTrajectoryParameter( string name, double value  );
         double                      GetTrajectoryDoubleParameter( string name );
 
-        svkEPSIReorder::EPSIType    GetEPSIType();
+        EPSIType                    GetEPSIType();
         const char*                 GetEPSITypeString();
         void                        AddEncodedMatrixSizeDimension( string name, int value);
         int                         GetEncodedMatrixSizeNumberOfDimensions();
@@ -152,7 +212,7 @@ class svkDataAcquisitionDescriptionXML: public vtkObject
 
 
     private:
-
+        vtkXMLDataElement*          GetEPSIEncodingElement();
         void                        SetTrajectoryParameter( string type, string name, string value  );
         string                      GetTrajectoryParameter( string type, string name );
         vtkXMLDataElement*          GetTrajectoryParameterElement( string type, string name );
@@ -173,42 +233,88 @@ class svkDataAcquisitionDescriptionXML: public vtkObject
 }   //svk
 #endif
 
-#endif //SVK_DATA_ACQUISITION_DESCRIPTION_XML_H
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+struct svkCString
+{
+    char c_str[256];
+};
 
-void*       svkDataAcquisitionDescriptionXML_New();
-void*       svkDataAcquisitionDescriptionXML_Delete( void* dataAcquisitionDescriptionXML );
-void*       svkDataAcquisitionDescriptionXML_Read(const char* xmlFileName, int* status);
-int         svkDataAcquisitionDescriptionXML_WriteXMLFile(const char* filepath, void* xml );
 
-const char* svkDataAcquisitionDescriptionXML_GetDataWithPath( void* xml, const char* path );
-int         svkDataAcquisitionDescriptionXML_SetDataWithPath( void* xml, const char* path, 
-                const char* data );
-int         svkDataAcquisitionDescriptionXML_AddElementWithParentPath( void* xml, const char* path, 
-                const char* name );
-int         svkDataAcquisitionDescriptionXML_RemoveElementWithParentPath( void* xml, 
-                const char* path, const char* name );
 
-void*       svkDataAcquisitionDescriptionXML_GetSatBandsXML( void* dataAcquisitionDescriptionXML ); 
-void        svkDataAcquisitionDescriptionXML_SetTrajectory(const char* type, const char* id, 
-                const char* comment, void* xml); 
-const char* svkDataAcquisitionDescriptionXML_GetTrajectoryType(void* xml); 
-const char* svkDataAcquisitionDescriptionXML_GetTrajectoryID(void* xml); 
-const char* svkDataAcquisitionDescriptionXML_GetTrajectoryComment(void* xml); 
-void        svkDataAcquisitionDescriptionXML_SetTrajectoryLongParameter(const char* name, 
-                long value, void* xml); 
-long        svkDataAcquisitionDescriptionXML_GetTrajectoryLongParameter(const char* name, void* xml); 
-void        svkDataAcquisitionDescriptionXML_SetTrajectoryDoubleParameter(const char* name, 
-                double value, void* xml); 
-double      svkDataAcquisitionDescriptionXML_GetTrajectoryDoubleParameter(const char* name, void* xml);
-void        svkDataAcquisitionDescriptionXML_AddEncodedMatrixSizeDimension(const char* name, int value, void* xml);
-int         svkDataAcquisitionDescriptionXML_GetEncodedMatrixSizeDimensionValue(int index, void* xml);
-const char* svkDataAcquisitionDescriptionXML_GetEncodedMatrixSizeDimensionName(int index, void* xml);
-int         svkDataAcquisitionDescriptionXML_GetEncodedMatrixSizeNumberOfDimensions(void* xml);
+void*             svkDataAcquisitionDescriptionXML_New();
+void*             svkDataAcquisitionDescriptionXML_Delete( void* dataAcquisitionDescriptionXML );
+void*             svkDataAcquisitionDescriptionXML_Read(const char* xmlFileName, int* status);
+int               svkDataAcquisitionDescriptionXML_WriteXMLFile(const char* filepath, void* xml );
+
+struct svkCString svkDataAcquisitionDescriptionXML_GetDataWithPath( void* xml, const char* path );
+int               svkDataAcquisitionDescriptionXML_SetDataWithPath( void* xml, const char* path, const char* data );
+int               svkDataAcquisitionDescriptionXML_AddElementWithParentPath( void* xml, const char* path,
+                                                                             const char* name );
+int               svkDataAcquisitionDescriptionXML_RemoveElementWithParentPath( void* xml,
+                                                                                const char* path, const char* name );
+
+void*             svkDataAcquisitionDescriptionXML_GetSatBandsXML( void* dataAcquisitionDescriptionXML );
+void              svkDataAcquisitionDescriptionXML_SetTrajectory(const char* type, const char* id,
+                                                                 const char* comment, void* xml);
+struct svkCString svkDataAcquisitionDescriptionXML_GetTrajectoryType(void* xml);
+struct svkCString svkDataAcquisitionDescriptionXML_GetTrajectoryID(void* xml);
+struct svkCString svkDataAcquisitionDescriptionXML_GetTrajectoryComment(void* xml);
+
+void              svkDataAcquisitionDescriptionXML_AddTrajectoryDimension(const char* id, const char* logical,
+                                                                          const char* description, void *xml);
+int               svkDataAcquisitionDescriptionXML_GetTrajectoryNumberOfDimensions(void *xml);                                  // New!
+struct svkCString svkDataAcquisitionDescriptionXML_GetTrajectoryDimensionId(int index, void *xml);                                // New!
+struct svkCString svkDataAcquisitionDescriptionXML_GetTrajectoryDimensionLogical(int index, void *xml);                           // New!
+struct svkCString svkDataAcquisitionDescriptionXML_GetTrajectoryDimensionDescription(int index, void *xml);                           // New!
+
+void              svkDataAcquisitionDescriptionXML_SetEPSITypeToFlyback(void* xml);
+void              svkDataAcquisitionDescriptionXML_SetEPSITypeToSymmetric(void* xml);
+void              svkDataAcquisitionDescriptionXML_SetEPSIType( enum EPSIType type, void* xml);
+enum EPSIType     svkDataAcquisitionDescriptionXML_GetEPSIType(void* xml);
+
+void              svkDataAcquisitionDescriptionXML_SetEPSINumberOfInterleaves( int numberOfInterleaves, void* xml);
+int               svkDataAcquisitionDescriptionXML_GetEPSINumberOfInterleaves( void* xml);
+
+void              svkDataAcquisitionDescriptionXML_SetEPSIGradientAmplitude(float amplitude, enum EPSILobe lobe, void* xml);
+float             svkDataAcquisitionDescriptionXML_GetEPSIGradientAmplitude(enum EPSILobe lobe, void* xml);
+
+void              svkDataAcquisitionDescriptionXML_SetEPSIRampDuration(float duration, enum EPSILobe lobe, void* xml);
+float             svkDataAcquisitionDescriptionXML_GetEPSIRampDuration(enum EPSILobe lobe, void* xml);
+
+void              svkDataAcquisitionDescriptionXML_SetEPSIPlateauDuration(float duration, enum EPSILobe lobe, void* xml);
+float             svkDataAcquisitionDescriptionXML_GetEPSIPlateauDuration(enum EPSILobe lobe, void* xml);
+
+void              svkDataAcquisitionDescriptionXML_SetEPSINumberOfLobes(int numberOfLobes, enum EPSILobe lobe, void* xml);
+float             svkDataAcquisitionDescriptionXML_GetEPSINumberOfLobes(enum EPSILobe lobe, void* xml);
+
+void              svkDataAcquisitionDescriptionXML_SetEPSISampleSpacing(float sampleSpacing, void* xml);
+float             svkDataAcquisitionDescriptionXML_GetEPSISampleSpacing(void* xml);
+
+void              svkDataAcquisitionDescriptionXML_SetEPSIAcquisitionDelay(float acquisitionDelay, void* xml);
+float             svkDataAcquisitionDescriptionXML_GetEPSIAcquisitionDelay(void* xml);
+
+void              svkDataAcquisitionDescriptionXML_SetEPSIEchoDelay(float echoDelay, void* xml);
+float             svkDataAcquisitionDescriptionXML_GetEPSIEchoDelay(void* xml);
+
+void              svkDataAcquisitionDescriptionXML_SetEPSIGradientAxis(int dimensionIndex, void* xml);
+struct svkCString svkDataAcquisitionDescriptionXML_GetEPSIGradientAxisId(void* xml);
+int               svkDataAcquisitionDescriptionXML_GetEPSIGradientAxisIndex(void* xml);
+
+void              svkDataAcquisitionDescriptionXML_SetTrajectoryLongParameter(const char* name,
+                                                                              long value, void* xml);
+long              svkDataAcquisitionDescriptionXML_GetTrajectoryLongParameter(const char* name, void* xml);
+void              svkDataAcquisitionDescriptionXML_SetTrajectoryDoubleParameter(const char* name,
+                                                                                double value, void* xml);
+double            svkDataAcquisitionDescriptionXML_GetTrajectoryDoubleParameter(const char* name, void* xml);
+void              svkDataAcquisitionDescriptionXML_AddEncodedMatrixSizeDimension(const char* name, int value,
+                                                                                 void* xml);
+int               svkDataAcquisitionDescriptionXML_GetEncodedMatrixSizeDimensionValue(int index, void* xml);
+struct svkCString svkDataAcquisitionDescriptionXML_GetEncodedMatrixSizeDimensionName(int index, void* xml);
+int               svkDataAcquisitionDescriptionXML_GetEncodedMatrixSizeNumberOfDimensions(void* xml);
 
 #ifdef __cplusplus
 }
 #endif
+#endif //SVK_DATA_ACQUISITION_DESCRIPTION_XML_H

--- a/libs/src/svkDataAcquisitionDescriptionXML.h
+++ b/libs/src/svkDataAcquisitionDescriptionXML.h
@@ -124,14 +124,14 @@ class svkDataAcquisitionDescriptionXML: public vtkObject
         vtkXMLDataElement*          FindNestedElementWithPath( string xmlPath);
         vtkXMLDataElement*          FindOrCreateNestedElementWithPath( string parentPath, string elementName);
 
-        const char*                 GetDataWithPath( const char* xmlPath );
+        string                      GetDataWithPath( const char* xmlPath );
         int                         GetIntByIndexWithParentPath( int index, const char* parentPath );
         int                         GetIntWithPath( const char* elementPath );
         void                        SetIntWithPath( const char* parentPath, const char* elmentName, int value );
         float                       GetFloatWithPath( const char* elementPath );
         void                        SetFloatWithPath( const char* parentPath, const char* elmentName, float value );
 
-        const char*                 GetDataByIndexWithParentPath( int index, const char* parentPath );
+        string                      GetDataByIndexWithParentPath( int index, const char* parentPath );
         vtkXMLDataElement*          GetNestedElementByIndexWithParentPath( int index, const char* parentPath );
 
         int                         SetDataWithPath( const char* xmlPath, const char* value );
@@ -196,10 +196,10 @@ class svkDataAcquisitionDescriptionXML: public vtkObject
         double                      GetTrajectoryDoubleParameter( string name );
 
         EPSIType                    GetEPSIType();
-        const char*                 GetEPSITypeString();
+        string                      GetEPSITypeString();
         void                        AddEncodedMatrixSizeDimension( string name, int value);
         int                         GetEncodedMatrixSizeNumberOfDimensions();
-        const char*                 GetEncodedMatrixSizeDimensionName(int index);
+        string                      GetEncodedMatrixSizeDimensionName(int index);
         int                         GetEncodedMatrixSizeDimensionValue(int index);
 
         int                         WriteXMLFile( string xmlFileName );

--- a/libs/src/svkDataAcquisitionDescriptionXML.h
+++ b/libs/src/svkDataAcquisitionDescriptionXML.h
@@ -51,14 +51,6 @@
  *
  */
 
-enum EPSIType
-{
-    UNDEFINED_EPSI_TYPE,
-    SYMMETRIC,
-    FLYBACK,
-    INTERLEAVED
-
-};
 
 enum EPSILobe
 {
@@ -74,6 +66,7 @@ enum EPSILobe
 #include <svkEPSIReorder.h>
 #include <svkXMLUtils.h>
 #include <svkInt.h>
+#include <svkEPSIReorder.h>
 
 #include "svkTypes.h"
 
@@ -236,6 +229,7 @@ class svkDataAcquisitionDescriptionXML: public vtkObject
 #ifdef __cplusplus
 extern "C" {
 #endif
+#include <svkTypes.h>
 struct svkCString
 {
     char c_str[256];
@@ -271,8 +265,8 @@ struct svkCString svkDataAcquisitionDescriptionXML_GetTrajectoryDimensionDescrip
 
 void              svkDataAcquisitionDescriptionXML_SetEPSITypeToFlyback(void* xml);
 void              svkDataAcquisitionDescriptionXML_SetEPSITypeToSymmetric(void* xml);
-void              svkDataAcquisitionDescriptionXML_SetEPSIType( enum EPSIType type, void* xml);
-enum EPSIType     svkDataAcquisitionDescriptionXML_GetEPSIType(void* xml);
+void              svkDataAcquisitionDescriptionXML_SetEPSIType( EPSIType type, void* xml);
+EPSIType          svkDataAcquisitionDescriptionXML_GetEPSIType(void* xml);
 
 void              svkDataAcquisitionDescriptionXML_SetEPSINumberOfInterleaves( int numberOfInterleaves, void* xml);
 int               svkDataAcquisitionDescriptionXML_GetEPSINumberOfInterleaves( void* xml);

--- a/libs/src/svkEPSIPhaseCorrect.cc
+++ b/libs/src/svkEPSIPhaseCorrect.cc
@@ -70,7 +70,7 @@ svkEPSIPhaseCorrect::svkEPSIPhaseCorrect()
     this->epsiOrigin = -1;
     this->epsiSpatialPhaseCorrection = NULL;
     this->symEPSIPhaseArray = NULL; 
-    this->epsiType =  svkEPSIReorder::FLYBACK; 
+    this->epsiType =  FLYBACK;
     this->phaseSlope = 1;   //positive slope shifts points to left
 }
 
@@ -86,7 +86,7 @@ svkEPSIPhaseCorrect::~svkEPSIPhaseCorrect()
 /*!
  *  Set the epsi type 
  */
-void svkEPSIPhaseCorrect::SetEPSIType( svkEPSIReorder::EPSIType type )
+void svkEPSIPhaseCorrect::SetEPSIType( EPSIType type )
 {
     this->epsiType = type;
 }
@@ -270,7 +270,7 @@ int svkEPSIPhaseCorrect::RequestData( vtkInformation* request, vtkInformationVec
 void svkEPSIPhaseCorrect::PhaseAlternatingSymmetricEPSILobes( int cellID )
 {
 
-    if ( this->epsiType == svkEPSIReorder::SYMMETRIC ) {
+    if ( this->epsiType == SYMMETRIC ) {
         //  Get pointer to input data set. 
         svkMrsImageData* mrsData = svkMrsImageData::SafeDownCast(this->GetImageDataInput(0)); 
     
@@ -375,7 +375,7 @@ void svkEPSIPhaseCorrect::CreateEPSIPhaseCorrectionFactors( vtkImageComplex** ep
     dtBs *= this->phaseSlope * 2 * Pi; 
     //  if sym EPSI divide mult by 2 since the cycle (num points in spectral bandwith is 
     //  twice as big)
-    if ( this->epsiType == svkEPSIReorder::SYMMETRIC ) {
+    if ( this->epsiType == SYMMETRIC ) {
         dtBs /= 2; 
     }
 

--- a/libs/src/svkEPSIPhaseCorrect.h
+++ b/libs/src/svkEPSIPhaseCorrect.h
@@ -91,7 +91,7 @@ class svkEPSIPhaseCorrect : public svkImageInPlaceFilter
         void            SetEPSIAxis( int epsiAxis );
         void            SetEPSIOrigin( float epsiOrigin );
         float           GetEPSIOrigin();
-        void            SetEPSIType( svkEPSIReorder::EPSIType type ); 
+        void            SetEPSIType( EPSIType type );
 
 
     protected:
@@ -122,7 +122,7 @@ class svkEPSIPhaseCorrect : public svkImageInPlaceFilter
         double*                  epsiSpatialPhaseCorrection;
         vtkImageComplex*         symEPSIPhaseArray; 
         svkImageData*            tmpData; 
-        svkEPSIReorder::EPSIType epsiType; 
+        EPSIType                 epsiType;
         int                      phaseSlope; 
 
 };

--- a/libs/src/svkEPSIReorder.cc
+++ b/libs/src/svkEPSIReorder.cc
@@ -70,7 +70,7 @@ svkEPSIReorder::svkEPSIReorder()
     vtkDebugMacro(<<this->GetClassName() << "::" << this->GetClassName() << "()");
 
     //  Initialize any member variables
-    this->epsiType = svkEPSIReorder::UNDEFINED_EPSI_TYPE; 
+    this->epsiType = UNDEFINED_EPSI_TYPE;
     this->numSamplesPerLobe = UNDEFINED_NUM_SAMPLES; 
     this->numLobes = UNDEFINED_NUM_LOBES; 
     this->numSamplesToSkip = 0; 
@@ -109,7 +109,7 @@ svkEPSIReorder::EPSIAxis svkEPSIReorder::GetEPSIAxis()
 /*!
  *  Set the type of EPSI sequence 
  */ 
-void svkEPSIReorder::SetEPSIType( svkEPSIReorder::EPSIType epsiType )
+void svkEPSIReorder::SetEPSIType( EPSIType epsiType )
 {
     this->epsiType = epsiType; 
 }
@@ -180,14 +180,14 @@ void svkEPSIReorder::SetFirstSample( int firstSample )
 int svkEPSIReorder::GetNumEPSIFrequencyPoints()
 {
     int numFreqPts;
-    if ( this->epsiType == svkEPSIReorder::UNDEFINED_EPSI_TYPE ) {
+    if ( this->epsiType == UNDEFINED_EPSI_TYPE ) {
         cout << "ERROR( " << this->GetClassName() << "): EPSI TYPE is undefined" << endl;
         exit(1); 
-    } else if ( this->epsiType == svkEPSIReorder::FLYBACK ) {
+    } else if ( this->epsiType == FLYBACK ) {
         numFreqPts = this->numLobes;     
-    } else if ( this->epsiType == svkEPSIReorder::SYMMETRIC ) {
+    } else if ( this->epsiType == SYMMETRIC ) {
         numFreqPts = this->numLobes / 2;     
-    } else if ( this->epsiType == svkEPSIReorder::INTERLEAVED ) {
+    } else if ( this->epsiType == INTERLEAVED ) {
         numFreqPts = this->numLobes;     
     } else {
         cout << "ERROR( " << this->GetClassName() << "): UNSUPPORTED EPSI TYPE " << endl;
@@ -206,14 +206,14 @@ int svkEPSIReorder::GetNumEPSIAcquisitions()
 {
     int numAcquisitions; 
 
-    if ( this->epsiType == svkEPSIReorder::UNDEFINED_EPSI_TYPE ) {
+    if ( this->epsiType == UNDEFINED_EPSI_TYPE ) {
         cout << "ERROR( " << this->GetClassName() << "): EPSI TYPE is undefined" << endl;
         exit(1); 
-    } else if ( this->epsiType == svkEPSIReorder::FLYBACK ) {
+    } else if ( this->epsiType == FLYBACK ) {
         numAcquisitions = 1; 
-    } else if ( this->epsiType == svkEPSIReorder::SYMMETRIC ) {
+    } else if ( this->epsiType == SYMMETRIC ) {
         numAcquisitions = 2; 
-    } else if ( this->epsiType == svkEPSIReorder::INTERLEAVED ) {
+    } else if ( this->epsiType == INTERLEAVED ) {
         numAcquisitions = 2; 
     } else {
         cout << "ERROR( " << this->GetClassName() << "): EPSI TYPE is undefined" << endl;
@@ -232,14 +232,14 @@ int svkEPSIReorder::GetNumEPSIAcquisitionsPerFID()
 {
     int numAcquisitionsPerFID; 
 
-    if ( this->epsiType == svkEPSIReorder::UNDEFINED_EPSI_TYPE ) {
+    if ( this->epsiType == UNDEFINED_EPSI_TYPE ) {
         cout << "ERROR( " << this->GetClassName() << "): EPSI TYPE is undefined" << endl;
         exit(1); 
-    } else if ( this->epsiType == svkEPSIReorder::FLYBACK ) {
+    } else if ( this->epsiType == FLYBACK ) {
         numAcquisitionsPerFID = 1; 
-    } else if ( this->epsiType == svkEPSIReorder::SYMMETRIC ) {
+    } else if ( this->epsiType == SYMMETRIC ) {
         numAcquisitionsPerFID = 2;  //for symmetric they are alternating in the same FID
-    } else if ( this->epsiType == svkEPSIReorder::INTERLEAVED ) {
+    } else if ( this->epsiType == INTERLEAVED ) {
         numAcquisitionsPerFID = 1;  // here they are already separated out into 2 "time points"
     } else {
         cout << "ERROR( " << this->GetClassName() << "): EPSI TYPE is undefined" << endl;
@@ -477,7 +477,7 @@ void svkEPSIReorder::ReorderEPSIData( svkImageData* data )
 
             //  For symmetric EPSI, EPSI_ACQ_INDEX isn't initialized in the input data, 
             //  so set it here: 
-            if ( this->epsiType == svkEPSIReorder::SYMMETRIC ) {
+            if ( this->epsiType == SYMMETRIC ) {
                 currentAcq = acq; //testing
             }
             //cout << "ACQ: " << acq << " " << currentAcq << endl;
@@ -485,7 +485,7 @@ void svkEPSIReorder::ReorderEPSIData( svkImageData* data )
             //  If numAcqs Per FID = 1, then reset the currentEPSIPt being read
             //  to the start of the FID: 
             //  if ( numEPSIAcquisitionsPerFID == 1 ) 
-            if ( this->epsiType == svkEPSIReorder::INTERLEAVED ) {
+            if ( this->epsiType == INTERLEAVED ) {
                 currentEPSIPt = this->firstSample;   
             }
 
@@ -561,7 +561,7 @@ void svkEPSIReorder::ReorderEPSIData( svkImageData* data )
     //svkDcmHeader::PrintDimensionIndexVector(&outDimensionVector);
 
     //  if interleaved EPSI, then interleave here. 
-    if ( this->epsiType == svkEPSIReorder::INTERLEAVED ) {
+    if ( this->epsiType == INTERLEAVED ) {
 
         //  combine interleaved data points here.  The spectra will be doubled in size, 
         //  but EPSI index will get dropped.so.. allocate a new data 

--- a/libs/src/svkEPSIReorder.h
+++ b/libs/src/svkEPSIReorder.h
@@ -45,6 +45,7 @@
 
 #include <vtkObject.h>
 #include <vtkObjectFactory.h>
+#include <svkTypes.h>
 
 #include <svkMrsImageFFT.h>
 #include <svkImageInPlaceFilter.h>
@@ -68,20 +69,13 @@ class svkEPSIReorder : public svkImageInPlaceFilter
         vtkTypeMacro( svkEPSIReorder, svkImageInPlaceFilter);
 
        typedef enum {
-            UNDEFINED_EPSI_TYPE = 0,
-            FLYBACK,
-            SYMMETRIC, 
-            INTERLEAVED 
-        } EPSIType;
-
-       typedef enum {
             UNDEFINED_EPSI_AXIS = -1,
             COLS,
             ROWS, 
             SLICES 
         } EPSIAxis;
 
-        void                        SetEPSIType( svkEPSIReorder::EPSIType epsiType );  
+        void                        SetEPSIType( EPSIType epsiType );
         void                        SetNumEPSILobes( int numLobes );  
         void                        SetNumSamplesPerLobe( int numSamples ); 
         int                         GetNumSamplesPerLobe(); 

--- a/libs/src/svkGEPFileMapper.cc
+++ b/libs/src/svkGEPFileMapper.cc
@@ -2176,8 +2176,8 @@ int svkGEPFileMapper::GetNumEPSIAcquisitions()
 
     int epsiType;
     if ( it != this->inputArgs.end() ) {
-        svkEPSIReorder::EPSIType epsiType = *( static_cast< svkEPSIReorder::EPSIType* >( this->inputArgs[ it->first ] ) );
-        if ( epsiType == svkEPSIReorder::SYMMETRIC || epsiType == svkEPSIReorder::INTERLEAVED ) {
+        EPSIType epsiType = *( static_cast< EPSIType* >( this->inputArgs[ it->first ] ) );
+        if ( epsiType == SYMMETRIC || epsiType == INTERLEAVED ) {
             numAcquisitions = 2; 
         }
     } 
@@ -2815,9 +2815,9 @@ void svkGEPFileMapper::ReorderEPSI( svkMrsImageData* data )
         map < string, void* >::iterator  it;
 
         it = this->inputArgs.find( "epsiType" );
-        svkEPSIReorder::EPSIType epsiType;
+        EPSIType epsiType;
         if ( it != this->inputArgs.end() ) {
-            epsiType = *( static_cast< svkEPSIReorder::EPSIType* >( this->inputArgs[ it->first ] ) );
+            epsiType = *( static_cast< EPSIType* >( this->inputArgs[ it->first ] ) );
         }
 
         it = this->inputArgs.find( "epsiAxis" );

--- a/libs/src/svkGEPFileMapperUCSFfidcsiDev0.cc
+++ b/libs/src/svkGEPFileMapperUCSFfidcsiDev0.cc
@@ -439,7 +439,16 @@ void svkGEPFileMapperUCSFfidcsiDev0::ReorderEPSIData( svkImageData* data )
 
     svkEPSIReorder::EPSIType epsiType = svkEPSIReorder::SYMMETRIC;
     if( this->dadFile != NULL ) {
-        epsiType = this->dadFile->GetEPSIType();
+        EPSIType epsiTypeFromDad = this->dadFile->GetEPSIType();
+        if( epsiTypeFromDad == SYMMETRIC ) {
+            epsiType = svkEPSIReorder::SYMMETRIC;
+        } else if ( epsiType == FLYBACK ) {
+            epsiType = svkEPSIReorder::FLYBACK;
+        } else if ( epsiType == INTERLEAVED ) {
+            epsiType = svkEPSIReorder::INTERLEAVED;
+        } else {
+            epsiType = svkEPSIReorder::UNDEFINED_EPSI_TYPE;
+        }
     }
     reorder->SetEPSIType( epsiType );
 

--- a/libs/src/svkGEPFileMapperUCSFfidcsiDev0.cc
+++ b/libs/src/svkGEPFileMapperUCSFfidcsiDev0.cc
@@ -437,18 +437,9 @@ void svkGEPFileMapperUCSFfidcsiDev0::ReorderEPSIData( svkImageData* data )
     svkEPSIReorder* reorder = svkEPSIReorder::New();    
     reorder->SetInputData( tmpReorderData );
 
-    svkEPSIReorder::EPSIType epsiType = svkEPSIReorder::SYMMETRIC;
-    if( this->dadFile != NULL ) {
-        EPSIType epsiTypeFromDad = this->dadFile->GetEPSIType();
-        if( epsiTypeFromDad == SYMMETRIC ) {
-            epsiType = svkEPSIReorder::SYMMETRIC;
-        } else if ( epsiType == FLYBACK ) {
-            epsiType = svkEPSIReorder::FLYBACK;
-        } else if ( epsiType == INTERLEAVED ) {
-            epsiType = svkEPSIReorder::INTERLEAVED;
-        } else {
-            epsiType = svkEPSIReorder::UNDEFINED_EPSI_TYPE;
-        }
+    EPSIType epsiType = SYMMETRIC;
+    if( this->dadFile != NULL && this->dadFile->GetEPSIType() != UNDEFINED_EPSI_TYPE ) {
+        epsiType = this->dadFile->GetEPSIType();
     }
     reorder->SetEPSIType( epsiType );
 
@@ -705,7 +696,7 @@ void svkGEPFileMapperUCSFfidcsiDev0::EPSIPhaseCorrection( svkImageData* data, in
     numRead -= 2; 
     epsiPhase->SetNumEPSIkRead( numRead );
     epsiPhase->SetEPSIAxis( epsiAxis );
-    epsiPhase->SetEPSIType( svkEPSIReorder::SYMMETRIC ); 
+    epsiPhase->SetEPSIType( SYMMETRIC );
     epsiPhase->SetInputData( tmpData ); 
     //tmpData->GetDcmHeader()->PrintDcmHeader(); 
     epsiPhase->Update(); 

--- a/libs/src/svkGEPFileReader.cc
+++ b/libs/src/svkGEPFileReader.cc
@@ -472,7 +472,7 @@ void svkGEPFileReader::SetMapperBehavior(svkGEPFileMapper::MapperBehavior type)
 
 /*!
  */
-void svkGEPFileReader::SetEPSIParams( svkEPSIReorder::EPSIType type, svkEPSIReorder::EPSIAxis axis, int first,
+void svkGEPFileReader::SetEPSIParams( EPSIType type, svkEPSIReorder::EPSIAxis axis, int first,
                                       int numLobes, int numSkip, int flipLobe )
 {
 

--- a/libs/src/svkGEPFileReader.cc.S
+++ b/libs/src/svkGEPFileReader.cc.S
@@ -477,7 +477,7 @@ void svkGEPFileReader::SetMapperBehavior(svkGEPFileMapper::MapperBehavior type)
 
 /*!
  */
-void svkGEPFileReader::SetEPSIParams( svkEPSIReorder::EPSIType type, svkEPSIReorder::EPSIAxis axis, int first, int numLobes, int numSkip ) 
+void svkGEPFileReader::SetEPSIParams( EPSIType type, svkEPSIReorder::EPSIAxis axis, int first, int numLobes, int numSkip )
 {
 
     int* epsiType     = new int (type);

--- a/libs/src/svkGEPFileReader.h
+++ b/libs/src/svkGEPFileReader.h
@@ -110,7 +110,7 @@ class svkGEPFileReader : public svkImageReader2
         void                PrintHeader();
         void                PrintShortHeader();
         void                SetEPSIParams( 
-                                svkEPSIReorder::EPSIType type, 
+                                EPSIType type,
                                 svkEPSIReorder::EPSIAxis axis, 
                                 int first, 
                                 int numLobes, 

--- a/libs/src/svkGEPFileReader.h.S
+++ b/libs/src/svkGEPFileReader.h.S
@@ -109,7 +109,7 @@ class svkGEPFileReader : public svkImageReader2
         void                PrintHeader();
         void                PrintShortHeader();
         void                SetEPSIParams( 
-                                svkEPSIReorder::EPSIType type, 
+                                EPSIType type,
                                 svkEPSIReorder::EPSIAxis axis, 
                                 int first, 
                                 int numLobes, 

--- a/libs/src/svkOverlayViewController.cc
+++ b/libs/src/svkOverlayViewController.cc
@@ -290,14 +290,14 @@ void svkOverlayViewController::SetInput( svkImageData* data, int index)
             this->view->SetInput(data, 1);
             this->SetSlice( this->GetView()->GetSlice() );
         }
-    } else if( index == svkOverlayView::OVERLAY != NULL && dataVector[MRI] != NULL ) {
+    } else if( index == svkOverlayView::OVERLAY && dataVector[MRI] != NULL ) {
         if( dataVector[svkOverlayView::OVERLAY] != NULL ) {
             dataVector[svkOverlayView::OVERLAY]->Delete();
         }
         data->Register( this );
         dataVector[svkOverlayView::OVERLAY] = data;
         this->view->SetInput( data, svkOverlayView::OVERLAY );
-    } else if( index == svkOverlayView::OVERLAY_CONTOUR != NULL && dataVector[MRI] != NULL ) {
+    } else if( index == svkOverlayView::OVERLAY_CONTOUR && dataVector[MRI] != NULL ) {
         data->Register( this );
         dataVector.push_back(data);
         this->view->SetInput( data, svkOverlayView::OVERLAY_CONTOUR );

--- a/libs/src/svkTypes.h
+++ b/libs/src/svkTypes.h
@@ -45,8 +45,14 @@
 
 
 //#include <vtkObjectFactory.h>
+typedef enum {
+    UNDEFINED_EPSI_TYPE = 0,
+    FLYBACK,
+    SYMMETRIC,
+    INTERLEAVED
+} EPSIType;
 
-
+#ifdef __cplusplus
 namespace svk {
 
 
@@ -65,6 +71,8 @@ class svkTypes : public vtkObject
             ANATOMY_BRAIN = 0,
             ANATOMY_PROSTATE
         } AnatomyType;
+
+
 
         static string  GetAnatomyTypeString( AnatomyType anatomyType ) 
         {
@@ -90,6 +98,6 @@ class svkTypes : public vtkObject
 };
 
 }
-
+#endif //__cplusplus
 #endif //SVK_TYPES_H
 

--- a/libs/src/svkXMLUtils.cc
+++ b/libs/src/svkXMLUtils.cc
@@ -139,6 +139,26 @@ vtkXMLDataElement* svkXMLUtils::FindNestedElementWithPath( vtkXMLDataElement* ro
 
 
 /*!
+ *  Finds a nested element at a depth greater than one. Searches from the root
+ *  node, and assumes a '/' separated list of nested elements. If element is not
+ *  found then it is created and returned.
+ */
+vtkXMLDataElement* svkXMLUtils::FindOrCreateNestedElementWithPath( vtkXMLDataElement* root, string parentPath, string elementName)
+{
+    vtkXMLDataElement* elem = NULL;
+    string elementPath = parentPath;
+    elementPath.append("/");
+    elementPath.append(elementName);
+    elem = svkXMLUtils::FindNestedElementWithPath(root, elementPath);
+    if( elem == NULL ) {
+        vtkXMLDataElement* parent = svkXMLUtils::FindNestedElementWithPath(root, parentPath);
+        elem = svkXMLUtils::CreateNestedXMLDataElement( parent, elementName, "" );
+    }
+    return elem;
+}
+
+
+/*!
  * Method finds a nested element and then grabs the character data and puts it
  * into the data string provided as an argument. If the character data is
  * retrieved then the method returns true, otherwise false.

--- a/libs/src/svkXMLUtils.h
+++ b/libs/src/svkXMLUtils.h
@@ -90,6 +90,7 @@ class svkXMLUtils : public vtkObject
                                     vector<string> xmlVariables 
                                   );
         static vtkXMLDataElement* FindNestedElementWithPath( vtkXMLDataElement* root, string xmlPath);
+        static vtkXMLDataElement* FindOrCreateNestedElementWithPath( vtkXMLDataElement* root, string parentPath, string elementName);
         static bool               GetNestedElementCharacterDataWithPath( vtkXMLDataElement* root, string xmlPath, string* data );
         static bool               SetNestedElementWithPath( vtkXMLDataElement* root, string xmlPath, string value );
         static void               ReadLine(ifstream* fs, istringstream* iss);   

--- a/tests/src/svkDadTrajectoryXMLTest.c
+++ b/tests/src/svkDadTrajectoryXMLTest.c
@@ -82,8 +82,8 @@ int base_test(const int argc, const char **argv) {
     svkDataAcquisitionDescriptionXML_SetTrajectoryDoubleParameter("myDoubleParam", myDoubleParam, dadXml );
 
     //Get the trajectory type
-    const char* trajectoryTypeTest = svkDataAcquisitionDescriptionXML_GetTrajectoryType( dadXml );
-    if(strcmp( trajectoryType, trajectoryTypeTest ) != 0 ){
+    struct svkCString trajectoryTypeTest = svkDataAcquisitionDescriptionXML_GetTrajectoryType( dadXml );
+    if(strcmp( trajectoryType, trajectoryTypeTest.c_str ) != 0 ){
         printf("ERROR: Trajectory type could not be set/get.\n");
         status = -1;
         return status;
@@ -91,8 +91,8 @@ int base_test(const int argc, const char **argv) {
     printf("Trajectory Type   : %s\n", trajectoryTypeTest);
 
     // Get a trajectory comment
-    const char* trajectoryIDTest = svkDataAcquisitionDescriptionXML_GetTrajectoryID( dadXml );
-    if(strcmp( trajectoryID, trajectoryIDTest ) != 0 ){
+    struct svkCString trajectoryIDTest = svkDataAcquisitionDescriptionXML_GetTrajectoryID( dadXml );
+    if(strcmp( trajectoryID, trajectoryIDTest.c_str ) != 0 ){
         printf("ERROR: Trajectory ID could not be set/get.\n");
         status = -1;
         return status;
@@ -100,8 +100,8 @@ int base_test(const int argc, const char **argv) {
     printf("Trajectory ID     : %s\n", trajectoryIDTest);
 
     // Get a trajectory comment
-    const char* trajectoryCommentTest = svkDataAcquisitionDescriptionXML_GetTrajectoryComment( dadXml );
-    if(strcmp( trajectoryComment, trajectoryCommentTest ) != 0 ){
+    struct svkCString trajectoryCommentTest = svkDataAcquisitionDescriptionXML_GetTrajectoryComment( dadXml );
+    if(strcmp( trajectoryComment, trajectoryCommentTest.c_str ) != 0 ){
         printf("ERROR: Trajectory comment could not be set/get.\n");
         status = -1;
         return status;
@@ -131,8 +131,8 @@ int base_test(const int argc, const char **argv) {
     int result = svkDataAcquisitionDescriptionXML_SetDataWithPath(dadXml, "encoding/trajectoryDescription/identifier", newID );
 
     // Use the generic getter to get data at a specific path
-    const char* currentID = svkDataAcquisitionDescriptionXML_GetDataWithPath(dadXml, "encoding/trajectoryDescription/identifier" );
-    if(strcmp( newID, currentID ) != 0 ){
+    struct svkCString currentID = svkDataAcquisitionDescriptionXML_GetDataWithPath(dadXml, "encoding/trajectoryDescription/identifier" );
+    if(strcmp( newID, currentID.c_str ) != 0 ){
         printf("ERROR: Identifier could not be set.");
         status = -1;
         return status;
@@ -172,12 +172,54 @@ int epsi_test(const int argc, const char **argv) {
     const char* trajectoryComment = "This is an epsi dataset..";
     svkDataAcquisitionDescriptionXML_SetTrajectory(trajectoryType, trajectoryID, trajectoryComment, dadXml );
 
+    svkDataAcquisitionDescriptionXML_AddTrajectoryDimension("dim1", "kx","", dadXml);
+    svkDataAcquisitionDescriptionXML_AddTrajectoryDimension("dim2", "ky","", dadXml);
+    svkDataAcquisitionDescriptionXML_AddTrajectoryDimension("dim3", "kz","", dadXml);
+    svkDataAcquisitionDescriptionXML_AddTrajectoryDimension("dim4", "kf","", dadXml);
+    svkDataAcquisitionDescriptionXML_AddTrajectoryDimension("dim5", "time_dynamic", "dynamic time points", dadXml);
     svkDataAcquisitionDescriptionXML_AddEncodedMatrixSizeDimension("x", 8, dadXml);
     svkDataAcquisitionDescriptionXML_AddEncodedMatrixSizeDimension("y", 7, dadXml);
     svkDataAcquisitionDescriptionXML_AddEncodedMatrixSizeDimension("z", 6, dadXml);
     svkDataAcquisitionDescriptionXML_AddEncodedMatrixSizeDimension("time_spec", 59, dadXml);
     svkDataAcquisitionDescriptionXML_AddEncodedMatrixSizeDimension("time_dynamic", 10, dadXml);
+    svkDataAcquisitionDescriptionXML_SetEPSIType( FLYBACK, dadXml );
+    int expectedNumberOfInterleaves = 11;
+    svkDataAcquisitionDescriptionXML_SetEPSINumberOfInterleaves( expectedNumberOfInterleaves, dadXml );
+    
+    float  expectedGradientAmplitudeEven = 10;
+    svkDataAcquisitionDescriptionXML_SetEPSIGradientAmplitude(expectedGradientAmplitudeEven, EVEN, dadXml);
+    float expectedGradientAmplitudeOdd = 11;
+    svkDataAcquisitionDescriptionXML_SetEPSIGradientAmplitude(expectedGradientAmplitudeOdd, ODD, dadXml);
 
+    float  expectedRampDurationEven = .180;
+    svkDataAcquisitionDescriptionXML_SetEPSIRampDuration(expectedRampDurationEven, EVEN, dadXml);
+    float expectedRampDurationOdd = .190;
+    svkDataAcquisitionDescriptionXML_SetEPSIRampDuration(expectedRampDurationOdd, ODD, dadXml);
+
+    float  expectedPlateauDurationEven = .560;
+    svkDataAcquisitionDescriptionXML_SetEPSIPlateauDuration(expectedPlateauDurationEven, EVEN, dadXml);
+    float expectedPlateauDurationOdd = .570;
+    svkDataAcquisitionDescriptionXML_SetEPSIPlateauDuration(expectedPlateauDurationOdd, ODD, dadXml);
+    
+    int  expectedNumberOfLobesEven = 53;
+    svkDataAcquisitionDescriptionXML_SetEPSINumberOfLobes(expectedNumberOfLobesEven, EVEN, dadXml);
+    int expectedNumberOfLobesOdd = 54;
+    svkDataAcquisitionDescriptionXML_SetEPSINumberOfLobes(expectedNumberOfLobesOdd, ODD, dadXml);
+    
+    float expectedSampleSpacing = 0.04;
+    svkDataAcquisitionDescriptionXML_SetEPSISampleSpacing(expectedSampleSpacing, dadXml);
+
+    float expectedAcquisitionDelay = 0.004;
+    svkDataAcquisitionDescriptionXML_SetEPSIAcquisitionDelay(expectedAcquisitionDelay, dadXml);
+
+    float expectedEchoDelay = 0.01;
+    svkDataAcquisitionDescriptionXML_SetEPSIEchoDelay(expectedEchoDelay, dadXml);
+
+    struct svkCString expectedGradientAxisId;
+    strcpy(expectedGradientAxisId.c_str, "dim3");
+    int expectedGradientAxisIndex = 3;
+    svkDataAcquisitionDescriptionXML_SetEPSIGradientAxis( expectedGradientAxisIndex, dadXml );
+    
     svkDataAcquisitionDescriptionXML_SetTrajectoryDoubleParameter("myDoubleParam", 0, dadXml );
 
     svkDataAcquisitionDescriptionXML_WriteXMLFile( argv[2], dadXml );
@@ -185,38 +227,183 @@ int epsi_test(const int argc, const char **argv) {
     dadXml = NULL;
     // Read the dad file back in
     dadXml =  svkDataAcquisitionDescriptionXML_Read(argv[2], &status);
-    int numberOfDimensions = svkDataAcquisitionDescriptionXML_GetEncodedMatrixSizeNumberOfDimensions(dadXml);
-    int xDim = svkDataAcquisitionDescriptionXML_GetEncodedMatrixSizeDimensionValue(0, dadXml);
-    if(xDim != 8) {
-        printf("Incorrect x matrix size. %d != 8\n", xDim);
-    } else {
-        printf("Correct x matrix size: %d\n", xDim);
-    }
-    const char* xDimName = svkDataAcquisitionDescriptionXML_GetEncodedMatrixSizeDimensionName(0, dadXml);
-    if(strcmp(xDimName, "x") != 0 ) {
-        printf("Incorrect x matrix size dimension name. %s != x\n", xDimName);
-    } else {
-        printf("Correct x matrix size name: %s\n", xDimName);
-    }
-    int yDim = svkDataAcquisitionDescriptionXML_GetEncodedMatrixSizeDimensionValue(1, dadXml);
-    if(yDim != 7) {
-        printf("Incorrect x matrix size. %d != 7\n", yDim);
-    } else {
-        printf("Correct x matrix size: %d\n", yDim);
-    }
-    const char* yDimName = svkDataAcquisitionDescriptionXML_GetEncodedMatrixSizeDimensionName(1, dadXml);
-    if(strcmp(yDimName, "y") != 0 ) {
-        printf("Incorrect y matrix size dimension name. %s != y\n", yDimName);
-    } else {
-        printf("Correct y matrix size name: %s\n", yDimName);
-    }
-    if( numberOfDimensions != 5) {
-        printf("Incorrect number of dimension %d != 5\n", numberOfDimensions);
-        return -1;
+
+    int actualNumDims = svkDataAcquisitionDescriptionXML_GetTrajectoryNumberOfDimensions(dadXml);
+    int expectedNumDims = 5;
+    if( actualNumDims != expectedNumDims ) {
+        printf("Incorrect number of dimension. Actual value <%d> is not equal to expected value <%d>\n",
+               actualNumDims, expectedNumDims);
+        status = -1;
     }
 
+    int actualMatrixSizeLength = svkDataAcquisitionDescriptionXML_GetEncodedMatrixSizeNumberOfDimensions(dadXml);
+    int expectedMatrixSizeLength = 5;
+    if( actualMatrixSizeLength != expectedMatrixSizeLength ) {
+        printf("Incorrect matrix size length. Actual value <%d> is not equal to expected value <%d>\n",
+               actualMatrixSizeLength, expectedMatrixSizeLength);
+        status = -1;
+    }
 
+    status = checkMatrixSize(dadXml, 0, "x", 8) != 0 ? -1: status;
+    status = checkMatrixSize(dadXml, 1, "y", 7) != 0 ? -1: status;
+    status = checkMatrixSize(dadXml, 2, "z", 6) != 0 ? -1: status;
+    status = checkMatrixSize(dadXml, 3, "time_spec", 59) != 0 ? -1: status;
+    status = checkMatrixSize(dadXml, 4, "time_dynamic", 10) != 0 ? -1: status;
+    status = checkDimensionDefinition(dadXml, 0, "dim1", "kx", "") != 0 ? -1: status;
+    status = checkDimensionDefinition(dadXml, 1, "dim2", "ky", "") != 0 ? -1: status;
+    status = checkDimensionDefinition(dadXml, 2, "dim3", "kz", "") != 0 ? -1: status;
+    status = checkDimensionDefinition(dadXml, 3, "dim4", "kf", "") != 0 ? -1: status;
+    status = checkDimensionDefinition(dadXml, 4, "dim5", "time_dynamic", "dynamic time points") != 0 ? -1: status;
+    if(  svkDataAcquisitionDescriptionXML_GetEPSIType(dadXml) != FLYBACK ) {
+        status = -1;
+    }
+    int actualNumberOfInterleaves = svkDataAcquisitionDescriptionXML_GetEPSINumberOfInterleaves(dadXml);
+    if( actualNumberOfInterleaves != expectedNumberOfInterleaves ) {
+        printf("Incorrect number of interleaves. Actual value <%d> is not equal to expected value <%d> \n",
+               actualNumberOfInterleaves, expectedNumberOfInterleaves);
+        status = -1;
+    }
+    
+    float actualGradientAmplitudeEven = svkDataAcquisitionDescriptionXML_GetEPSIGradientAmplitude(EVEN, dadXml);
+    if(  actualGradientAmplitudeEven != expectedGradientAmplitudeEven ) {
+        printf("Incorrect gradient amplitude even. Actual value <%f> is not equal to expected value <%f> \n",
+        actualGradientAmplitudeEven, expectedGradientAmplitudeEven);
+        status = -1;
+    }
+    float actualGradientAmplitudeOdd = svkDataAcquisitionDescriptionXML_GetEPSIGradientAmplitude(ODD, dadXml);
+    if(  actualGradientAmplitudeOdd != expectedGradientAmplitudeOdd ) {
+        printf("Incorrect gradient amplitude odd. Actual value <%f> is not equal to expected value <%f> \n",
+               actualGradientAmplitudeOdd, expectedGradientAmplitudeOdd);
+        status = -1;
+    }
+    
+    float actualRampDurationEven = svkDataAcquisitionDescriptionXML_GetEPSIRampDuration(EVEN, dadXml);
+    if(  actualRampDurationEven != expectedRampDurationEven ) {
+        printf("Incorrect ramp duration even. Actual value <%f> is not equal to expected value <%f> \n",
+               actualRampDurationEven, expectedRampDurationEven);
+        status = -1;
+    }
+    float actualRampDurationOdd = svkDataAcquisitionDescriptionXML_GetEPSIRampDuration(ODD, dadXml);
+    if(  actualRampDurationOdd != expectedRampDurationOdd ) {
+        printf("Incorrect ramp duration odd. Actual value <%f> is not equal to expected value <%f> \n",
+               actualRampDurationOdd, expectedRampDurationOdd);
+        status = -1;
+    }
 
+    float actualPlateauDurationEven = svkDataAcquisitionDescriptionXML_GetEPSIPlateauDuration(EVEN, dadXml);
+    if(  actualPlateauDurationEven != expectedPlateauDurationEven ) {
+        printf("Incorrect plateau duration even. Actual value <%f> is not equal to expected value <%f> \n",
+               actualPlateauDurationEven, expectedPlateauDurationEven);
+        status = -1;
+    }
+    float actualPlateauDurationOdd = svkDataAcquisitionDescriptionXML_GetEPSIPlateauDuration(ODD, dadXml);
+    if(  actualPlateauDurationOdd != expectedPlateauDurationOdd ) {
+        printf("Incorrect plateau duration odd. Actual value <%f> is not equal to expected value <%f> \n",
+               actualPlateauDurationOdd, expectedPlateauDurationOdd);
+        status = -1;
+    }
+
+    int actualNumberOfLobesEven = svkDataAcquisitionDescriptionXML_GetEPSINumberOfLobes(EVEN, dadXml);
+    if(  actualNumberOfLobesEven != expectedNumberOfLobesEven ) {
+        printf("Incorrect number of lobes even. Actual value <%f> is not equal to expected value <%f> \n",
+               actualNumberOfLobesEven, expectedNumberOfLobesEven);
+        status = -1;
+    }
+    int actualNumberOfLobesOdd = svkDataAcquisitionDescriptionXML_GetEPSINumberOfLobes(ODD, dadXml);
+    if(  actualNumberOfLobesOdd != expectedNumberOfLobesOdd ) {
+        printf("Incorrect number of lobes odd. Actual value <%f> is not equal to expected value <%f> \n",
+               actualNumberOfLobesOdd, expectedNumberOfLobesOdd);
+        status = -1;
+    }
+    
+    float actualSampleSpacing = svkDataAcquisitionDescriptionXML_GetEPSISampleSpacing(dadXml);
+    if(  actualSampleSpacing != expectedSampleSpacing ) {
+        printf("Incorrect sample spacing. Actual value <%f> is not equal to expected value <%f> \n",
+               actualSampleSpacing, expectedSampleSpacing);
+        status = -1;
+    }
+
+    float actualAcquisitionDelay = svkDataAcquisitionDescriptionXML_GetEPSIAcquisitionDelay(dadXml);
+    if(  actualAcquisitionDelay != expectedAcquisitionDelay ) {
+        printf("Incorrect acquisition delay. Actual value <%f> is not equal to expected value <%f> \n",
+               actualAcquisitionDelay, expectedAcquisitionDelay);
+        status = -1;
+    }
+    
+    float actualEchoDelay = svkDataAcquisitionDescriptionXML_GetEPSIEchoDelay(dadXml);
+    if(  actualEchoDelay != expectedEchoDelay ) {
+        printf("Incorrect echo delay. Actual value <%f> is not equal to expected value <%f> \n",
+               actualEchoDelay, expectedEchoDelay);
+        status = -1;
+    }
+
+    struct svkCString actualGradientAxisId = svkDataAcquisitionDescriptionXML_GetEPSIGradientAxisId(dadXml);
+    if(  strcmp(actualGradientAxisId.c_str, expectedGradientAxisId.c_str) != 0) {
+        printf("Incorrect gradient axis id. Actual value <%s> is not equal to expected value <%s> \n",
+               actualGradientAxisId.c_str, expectedGradientAxisId.c_str);
+        status = -1;
+    }
+
+    int actualGradientAxisIndex = svkDataAcquisitionDescriptionXML_GetEPSIGradientAxisIndex(dadXml);
+    if( actualGradientAxisIndex != expectedGradientAxisIndex ) {
+        printf("Incorrect gradient axis index. Actual value <%d> is not equal to expected value <%d> \n",
+               actualGradientAxisIndex, expectedGradientAxisIndex);
+        status = -1;
+    }
     return status;
 }
+
+
+int checkMatrixSize(const void *dadXml, int dimIndex, const char *expectedDimName, int expectedValue) {
+    int status = 0;
+    if(dadXml == NULL ) {
+        printf("XML is NULL!\n");
+        return -1;
+    }
+    struct svkCString actualDimName = svkDataAcquisitionDescriptionXML_GetEncodedMatrixSizeDimensionName(dimIndex, dadXml);
+    if(strcmp(actualDimName.c_str, expectedDimName) != 0 ) {
+        printf("Incorrect dimension name for index %d. Actual value <%s> is not equal to expected value <%s> \n", dimIndex,
+               actualDimName.c_str, expectedDimName);
+        status = -1;
+    }
+    int actualValue = svkDataAcquisitionDescriptionXML_GetEncodedMatrixSizeDimensionValue(dimIndex, dadXml);
+    if(actualValue != expectedValue) {
+        printf("Incorrect dimension matrix size for index %d. Actual value %d is not equal to expected value %d \n", dimIndex,
+               actualValue, expectedValue );
+        status = -1;
+    }
+    return status;
+}
+
+
+int checkDimensionDefinition(const void *dadXml, int dimIndex, const char *expectedDimId,
+                             const char* expectedDimLogical, const char* expectedDimDescription) {
+    int status = 0;
+    if(dadXml == NULL ) {
+        printf("XML is NULL!\n");
+        return -1;
+    }
+    struct svkCString actualDimId = svkDataAcquisitionDescriptionXML_GetTrajectoryDimensionId(dimIndex, dadXml);
+    if(strcmp(actualDimId.c_str, expectedDimId) != 0 ) {
+        printf("Incorrect dimension ID for index %d. Actual value <%s> is not equal to expected value <%s> \n", dimIndex,
+               actualDimId.c_str, expectedDimId);
+        status = -1;
+    }
+
+    struct svkCString actualDimLogical = svkDataAcquisitionDescriptionXML_GetTrajectoryDimensionLogical(dimIndex, dadXml);
+    if(strcmp(actualDimLogical.c_str, expectedDimLogical) != 0 ) {
+        printf("Incorrect dimension Logical for index %d. Actual value <%s> is not equal to expected value <%s> \n", dimIndex,
+               actualDimLogical.c_str, expectedDimLogical);
+        status = -1;
+    }
+
+    struct svkCString actualDimDescription = svkDataAcquisitionDescriptionXML_GetTrajectoryDimensionDescription(dimIndex, dadXml);
+    if(strcmp(actualDimDescription.c_str, expectedDimDescription) != 0 ) {
+        printf("Incorrect dimension Description for index %d. Actual value <%s> is not equal to expected value <%s> \n", dimIndex,
+               actualDimDescription.c_str, expectedDimDescription);
+        status = -1;
+    }
+    return status;
+}
+
 

--- a/tests/src/svkDadTrajectoryXMLTest.c
+++ b/tests/src/svkDadTrajectoryXMLTest.c
@@ -195,7 +195,7 @@ int epsi_test(const int argc, const char **argv) {
         status = -1;
     }
 
-    enum EPSIType expectedEPSIType = INTERLEAVED;
+    EPSIType expectedEPSIType = INTERLEAVED;
     svkDataAcquisitionDescriptionXML_SetEPSIType( expectedEPSIType, dadXml );
     int expectedNumberOfInterleaves = 11;
     svkDataAcquisitionDescriptionXML_SetEPSINumberOfInterleaves( expectedNumberOfInterleaves, dadXml );
@@ -269,7 +269,7 @@ int epsi_test(const int argc, const char **argv) {
     status = checkDimensionDefinition(dadXml, 2, "dim3", "kz", "") != 0 ? -1: status;
     status = checkDimensionDefinition(dadXml, 3, "dim4", "kf", "") != 0 ? -1: status;
     status = checkDimensionDefinition(dadXml, 4, "dim5", "time_dynamic", "dynamic time points") != 0 ? -1: status;
-    enum EPSIType actualEPSIType = svkDataAcquisitionDescriptionXML_GetEPSIType(dadXml);
+    EPSIType actualEPSIType = svkDataAcquisitionDescriptionXML_GetEPSIType(dadXml);
     if(   actualEPSIType != expectedEPSIType) {
         printf("Incorrect EPSI Type. Actual value <%d> is not equal to expected value <%d> \n",
                actualEPSIType, expectedEPSIType);
@@ -372,7 +372,7 @@ int epsi_test(const int argc, const char **argv) {
 }
 
 
-int checkMatrixSize(const void *dadXml, int dimIndex, const char *expectedDimName, int expectedValue) {
+int checkMatrixSize(void *dadXml, int dimIndex, const char *expectedDimName, int expectedValue) {
     int status = 0;
     if(dadXml == NULL ) {
         printf("XML is NULL!\n");
@@ -394,7 +394,7 @@ int checkMatrixSize(const void *dadXml, int dimIndex, const char *expectedDimNam
 }
 
 
-int checkDimensionDefinition(const void *dadXml, int dimIndex, const char *expectedDimId,
+int checkDimensionDefinition(void *dadXml, int dimIndex, const char *expectedDimId,
                              const char* expectedDimLogical, const char* expectedDimDescription) {
     int status = 0;
     if(dadXml == NULL ) {


### PR DESCRIPTION
Updates to expand DAD API. Additionally some fixes for compiler warnings.

A couple of notable changes here:
1. I moved the EPSIType enum out of svkEPSIReoder into svkType.h so that it could be used in c-code.
2. I changed the return types in c to a new svkCString type to avoid the memory errors we've been seeing on mac osx. Unfortunately these means existing code may break with this update.